### PR TITLE
Close button integration

### DIFF
--- a/apps/web/src/components/ide/editor-tabs.tsx
+++ b/apps/web/src/components/ide/editor-tabs.tsx
@@ -52,7 +52,7 @@ function TabItem({
   return (
     <div
       className={cn(
-        "group relative flex h-full min-w-0 max-w-[180px] select-none items-center border-r border-border/60 text-[13px] transition-colors",
+        "group relative flex h-full min-w-0 max-w-[180px] select-none items-center border-r border-border/60 pr-1 text-[13px] transition-colors",
         active
           ? "bg-background text-foreground"
           : "bg-muted/40 text-muted-foreground hover:bg-muted/70",
@@ -92,9 +92,12 @@ function TabItem({
       </div>
       <button
         className={cn(
-          "flex size-5 shrink-0 items-center justify-center rounded transition-colors hover:bg-foreground/10",
+          "flex size-5 shrink-0 items-center justify-center rounded-sm transition-colors",
           "opacity-0 group-hover:opacity-100",
-          active && "opacity-70"
+          active && "opacity-100",
+          active
+            ? "hover:bg-foreground/5 text-foreground"
+            : "hover:bg-foreground/5 text-muted-foreground"
         )}
         onClick={(e) => {
           e.stopPropagation();


### PR DESCRIPTION
Refactor editor tab close button styling to improve integration.

The close button now has a softer hover state, a smaller rounded radius, remains visible on active tabs, aligns its color with the tab's active/inactive state, and is positioned with right padding to sit within the tab.

---
<p><a href="https://cursor.com/agents/bc-8732e002-ad99-4d1a-9614-62e077241dbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8732e002-ad99-4d1a-9614-62e077241dbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

