### PR TITLE
Blog post rendering broken

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -230,12 +230,12 @@
   margin-right: 0 !important;
   margin-left: 0 !important;
 }
-/* IDE preview: center content horizontally and vertically */
+/* IDE preview: center content horizontally, align to top for scrollable content */
 [data-ide-main][data-preview] {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   min-height: 100%;
 }
 


### PR DESCRIPTION
Update `justify-content` in `globals.css` to fix blog post content being cut off in the IDE preview.

The `justify-content: center` property was vertically centering content within the IDE preview, causing the top of blog posts (title, back link) to be pushed out of view when the content exceeded the viewport height. Changing it to `flex-start` ensures content starts at the top and scrolls normally.

---
<p><a href="https://cursor.com/agents/bc-5815d01d-89f3-4d7c-9cbf-a027afbb1330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5815d01d-89f3-4d7c-9cbf-a027afbb1330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

