### PR TITLE
fix(web): show full IDE skeleton during initial load

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { Toaster } from "@portfolio/ui";
 import Script from "next/script";
 import { UmamiScript } from "@/components/analytics/umami-script";
 import { IdeLayout } from "@/components/ide/ide-layout";
+import { IdeLayoutSkeleton } from "@/components/ide/ide-layout-skeleton";
 import { ThemePresetProvider } from "@/components/theming/theme-preset-context";
 import { ThemeProvider } from "@/components/theming/provider";
 import "@/styles/globals.css";
@@ -84,14 +85,10 @@ export default async function LocaleLayout({ children, params }: Props) {
             >
               <ThemePresetProvider>
                 <Suspense
-                fallback={
-                  <div className="flex min-h-dvh items-center justify-center">
-                    {children}
-                  </div>
-                }
-              >
-                <IdeLayout>{children}</IdeLayout>
-              </Suspense>
+                  fallback={<IdeLayoutSkeleton>{children}</IdeLayoutSkeleton>}
+                >
+                  <IdeLayout>{children}</IdeLayout>
+                </Suspense>
                 <Toaster richColors />
               </ThemePresetProvider>
             </ThemeProvider>

--- a/apps/web/src/components/ide/ide-layout-skeleton.tsx
+++ b/apps/web/src/components/ide/ide-layout-skeleton.tsx
@@ -1,0 +1,75 @@
+import { Skeleton } from "@portfolio/ui";
+
+interface IdeLayoutSkeletonProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Skeleton shell matching IdeLayout structure. Shown during initial load
+ * so the IDE chrome appears immediately instead of content-first.
+ */
+export function IdeLayoutSkeleton({ children }: IdeLayoutSkeletonProps) {
+  return (
+    <div className="flex h-dvh flex-col overflow-hidden bg-background">
+      {/* Title bar */}
+      <div className="flex h-9 shrink-0 items-center border-border border-b bg-secondary px-2 shadow-[var(--shadow-elevation-sm)] sm:px-4">
+        <div className="flex shrink-0 items-center gap-2 pr-2">
+          <div className="flex size-10 md:hidden" />
+          <div className="hidden gap-[7px] md:flex">
+            <Skeleton className="size-3 rounded-full" />
+            <Skeleton className="size-3 rounded-full" />
+            <Skeleton className="size-3 rounded-full" />
+          </div>
+        </div>
+        <div className="flex min-w-0 flex-1 justify-center">
+          <Skeleton className="h-3 w-24" />
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {/* Activity bar */}
+        <div className="hidden h-full w-12 shrink-0 flex-col items-center border-border border-r bg-sidebar py-1 md:flex">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <Skeleton className="size-10 rounded-none" key={i} />
+          ))}
+        </div>
+
+        {/* Sidebar */}
+        <div className="hidden w-56 shrink-0 flex-col border-border border-r bg-sidebar md:flex">
+          <div className="border-border border-b px-2 py-2">
+            <Skeleton className="h-3 w-16" />
+          </div>
+          <div className="flex-1 space-y-1 p-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-[75%]" />
+            <Skeleton className="h-4 w-5/6" />
+          </div>
+        </div>
+
+        {/* Main content */}
+        <div className="flex w-full min-w-0 flex-1 flex-col overflow-hidden">
+          <div className="hidden shrink-0 border-border border-b md:block">
+            <Skeleton className="h-9 w-full" />
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="shrink-0 border-border border-b px-2 py-1.5">
+              <Skeleton className="h-4 w-32" />
+            </div>
+            <main className="min-h-0 w-full min-w-0 flex-1 overflow-y-auto">
+              {children}
+            </main>
+          </div>
+        </div>
+      </div>
+
+      {/* Status bar */}
+      <div className="hidden h-11 shrink-0 items-center justify-between border-border border-t bg-secondary px-2 py-1 md:flex sm:h-6 sm:px-3 sm:py-0">
+        <Skeleton className="h-3 w-16" />
+        <div className="flex gap-2">
+          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-3 w-14" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes the jarring loading experience where page content appeared first without the IDE chrome, then the full layout loaded.

**Changes:**
- Add `IdeLayoutSkeleton` component that mirrors the IDE structure (title bar, activity bar, sidebar, main area, status bar) with skeleton placeholders
- Update layout Suspense fallback to use `IdeLayoutSkeleton` instead of a centered div
- Users now see the full IDE shell immediately with loading content in the main area