### PR TITLE
Portfolio initial load

### DIFF
--- a/apps/web/src/app/[locale]/loading.tsx
+++ b/apps/web/src/app/[locale]/loading.tsx
@@ -1,36 +1,5 @@
-import { Separator, Skeleton } from "@portfolio/ui";
-import { PageContent } from "@/components/shared/page-content";
+import { PageLoadingSkeleton } from "@/components/ide/page-loading-skeleton";
 
 export default function Loading() {
-  return (
-    <PageContent>
-      <Skeleton className="h-4 w-20" />
-      <header className="space-y-1.5">
-        <Skeleton className="h-5 w-28" />
-        <Skeleton className="h-4 w-40" />
-      </header>
-      <Skeleton className="h-12 w-full" />
-      <Separator className="bg-border/50" />
-      <div className="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-4 sm:gap-4">
-        {[1, 2, 3, 4].map((i) => (
-          <Skeleton className="h-4 w-16" key={`social-${i}`} />
-        ))}
-      </div>
-      <Separator className="bg-border/50" />
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <Skeleton className="h-4 w-16" />
-          <Skeleton className="h-3 w-14" />
-        </div>
-        <div className="space-y-1">
-          {[1, 2, 3].map((i) => (
-            <Skeleton
-              className="h-14 w-full rounded-md sm:h-12"
-              key={`feat-${i}`}
-            />
-          ))}
-        </div>
-      </div>
-    </PageContent>
-  );
+  return <PageLoadingSkeleton />;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,25 @@ import { defaultLocale } from "@portfolio/i18n/config";
 import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Suspense } from "react";
 import { baseUrl } from "@/lib/metadata";
+
+/** Minimal IDE shell for initial load - no @portfolio/ui to avoid barrel import issues */
+function InitialLoadShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-dvh flex-col overflow-hidden bg-background">
+      <div className="flex h-9 shrink-0 items-center border-border border-b bg-secondary px-2 sm:px-4" />
+      <div className="flex min-h-0 flex-1">
+        <div className="hidden w-12 shrink-0 border-border border-r bg-sidebar md:block" />
+        <div className="hidden w-56 shrink-0 border-border border-r bg-sidebar md:block" />
+        <main className="min-h-0 w-full min-w-0 flex-1 overflow-y-auto">
+          {children}
+        </main>
+      </div>
+      <div className="hidden h-11 shrink-0 border-border border-t bg-secondary md:block" />
+    </div>
+  );
+}
 
 export const metadata: Metadata = {
   metadataBase: baseUrl,
@@ -40,7 +58,46 @@ export default function RootLayout({
             strategy="afterInteractive"
           />
         )}
-        {children}
+        <Suspense
+          fallback={
+            <InitialLoadShell>
+              <div className="mx-auto max-w-2xl space-y-5 px-4 py-6 sm:max-w-4xl sm:space-y-6 sm:px-6 sm:py-8">
+                <div className="animate-pulse rounded-md bg-accent h-4 w-20" />
+                <header className="space-y-1.5">
+                  <div className="animate-pulse rounded-md bg-accent h-5 w-28" />
+                  <div className="animate-pulse rounded-md bg-accent h-4 w-40" />
+                </header>
+                <div className="animate-pulse rounded-md bg-accent h-12 w-full" />
+                <div className="h-px w-full bg-border" />
+                <div className="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-4 sm:gap-4">
+                  {[1, 2, 3, 4].map((i) => (
+                    <div
+                      className="animate-pulse rounded-md bg-accent h-4 w-16"
+                      key={i}
+                    />
+                  ))}
+                </div>
+                <div className="h-px w-full bg-border" />
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div className="animate-pulse rounded-md bg-accent h-4 w-16" />
+                    <div className="animate-pulse rounded-md bg-accent h-3 w-14" />
+                  </div>
+                  <div className="space-y-1">
+                    {[1, 2, 3].map((i) => (
+                      <div
+                        className="animate-pulse rounded-md bg-accent h-14 w-full sm:h-12"
+                        key={i}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </InitialLoadShell>
+          }
+        >
+          {children}
+        </Suspense>
       </body>
     </html>
   );

--- a/apps/web/src/components/ide/page-loading-skeleton.tsx
+++ b/apps/web/src/components/ide/page-loading-skeleton.tsx
@@ -1,0 +1,41 @@
+import { Separator, Skeleton } from "@portfolio/ui";
+import { PageContent } from "@/components/shared/page-content";
+
+/**
+ * Skeleton content for the main editor area during initial load.
+ * Matches the home page structure for a smooth transition.
+ * Used in both root layout Suspense fallback and [locale] loading.tsx.
+ */
+export function PageLoadingSkeleton() {
+  return (
+    <PageContent>
+      <Skeleton className="h-4 w-20" />
+      <header className="space-y-1.5">
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-4 w-40" />
+      </header>
+      <Skeleton className="h-12 w-full" />
+      <Separator className="bg-border/50" />
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-4 sm:gap-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton className="h-4 w-16" key={`social-${i}`} />
+        ))}
+      </div>
+      <Separator className="bg-border/50" />
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-3 w-14" />
+        </div>
+        <div className="space-y-1">
+          {[1, 2, 3].map((i) => (
+            <Skeleton
+              className="h-14 w-full rounded-md sm:h-12"
+              key={`feat-${i}`}
+            />
+          ))}
+        </div>
+      </div>
+    </PageContent>
+  );
+}


### PR DESCRIPTION
Refactor initial portfolio load to display the IDE shell immediately, improving the user experience.

The previous initial load showed content skeletons without the IDE shell, which then appeared around them. This PR introduces a root-level Suspense boundary with an `InitialLoadShell` fallback, ensuring the IDE shell (title bar, sidebar, main area) appears instantly when the locale layout suspends on `getMessages()`. It also extracts page loading content into a shared `PageLoadingSkeleton` and uses a minimal, inline fallback to avoid `@portfolio/ui` dependencies during the initial load.

---
<p><a href="https://cursor.com/agents/bc-69b5188c-2a2e-4dbf-a6da-277c33db85fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69b5188c-2a2e-4dbf-a6da-277c33db85fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

