### PR TITLE
Shadcn theme integration

### DIFF
--- a/apps/web/src/components/ide/editor/breadcrumbs.tsx
+++ b/apps/web/src/components/ide/editor/breadcrumbs.tsx
@@ -29,7 +29,12 @@ export const Breadcrumbs = memo(function Breadcrumbs({
           const key = parts.slice(0, i + 1).join("/");
           return (
             <span className="flex items-center gap-1" key={key}>
-              {i > 0 && <ChevronRight className="size-3 opacity-50" />}
+              {i > 0 && (
+                <ChevronRight
+                  aria-hidden
+                  className="size-3 shrink-0 text-muted-foreground/50"
+                />
+              )}
               <span
                 className={cn(
                   "truncate",

--- a/apps/web/src/components/ide/editor/editor-content-context-menu.tsx
+++ b/apps/web/src/components/ide/editor/editor-content-context-menu.tsx
@@ -29,7 +29,7 @@ export function EditorContentContextMenu({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-      <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5 shadow-lg">
+      <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5">
         {onCopy && (
           <ContextMenuItem onClick={onCopy}>
             <Copy className="mr-2 size-3.5" />

--- a/apps/web/src/components/ide/editor/editor-tab-context-menu.tsx
+++ b/apps/web/src/components/ide/editor/editor-tab-context-menu.tsx
@@ -41,7 +41,7 @@ export function EditorTabContextMenu({
   const t = useTranslations("ide");
 
   return (
-    <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5 shadow-lg">
+    <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5">
       <ContextMenuItem onClick={() => onCloseTab(itemHref)}>
         {t("close")}
       </ContextMenuItem>

--- a/apps/web/src/components/ide/layout/activity-bar-settings-menu.tsx
+++ b/apps/web/src/components/ide/layout/activity-bar-settings-menu.tsx
@@ -91,7 +91,7 @@ export function ActivityBarSettingsMenu({
       </Tooltip>
       <DropdownMenuContent
         align="start"
-        className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5 shadow-lg"
+        className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5"
         side="right"
       >
         <DropdownMenuItem onClick={handleThemeToggle}>
@@ -114,7 +114,7 @@ export function ActivityBarSettingsMenu({
             {t("themePreset")}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent
-            className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5 shadow-lg"
+            className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5"
             sideOffset={4}
           >
             <DropdownMenuRadioGroup
@@ -140,7 +140,7 @@ export function ActivityBarSettingsMenu({
             {t("language")}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent
-            className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5 shadow-lg"
+            className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5"
             sideOffset={4}
           >
             <DropdownMenuRadioGroup

--- a/apps/web/src/components/ide/sidebar/collapsible-section.tsx
+++ b/apps/web/src/components/ide/sidebar/collapsible-section.tsx
@@ -24,7 +24,10 @@ export function CollapsibleSection({
         onClick={() => setOpen(!open)}
         type="button"
       >
-        <Chevron className="size-3.5 shrink-0 opacity-70" />
+        <Chevron
+          aria-hidden
+          className="size-3.5 shrink-0 text-muted-foreground/70"
+        />
         {title}
       </button>
       {open && children}

--- a/apps/web/src/components/ide/sidebar/commit-history-item.tsx
+++ b/apps/web/src/components/ide/sidebar/commit-history-item.tsx
@@ -42,7 +42,7 @@ export function CommitHistoryItem({ commit }: CommitHistoryItemProps) {
       </HoverCardTrigger>
       <HoverCardContent
         align="start"
-        className="ide-dropdown w-72 rounded-sm border border-border bg-popover p-3 shadow-lg"
+        className="ide-dropdown w-72 rounded-sm border border-border bg-popover p-3"
         side="right"
       >
         <div className="space-y-2.5">

--- a/apps/web/src/components/ide/sidebar/commit-history-item.tsx
+++ b/apps/web/src/components/ide/sidebar/commit-history-item.tsx
@@ -59,7 +59,7 @@ export function CommitHistoryItem({ commit }: CommitHistoryItemProps) {
             </p>
           )}
           <div className="flex flex-wrap items-center gap-1.5">
-            <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium text-[10px] text-blue-600 dark:text-blue-400">
+            <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium text-[10px] text-primary">
               <GitBranch className="size-3" />
               main
             </span>

--- a/apps/web/src/components/ide/sidebar/explorer-tree-item.tsx
+++ b/apps/web/src/components/ide/sidebar/explorer-tree-item.tsx
@@ -95,7 +95,7 @@ export function ExplorerTreeItem({
             </div>
           )}
         </div>
-        <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5 shadow-lg">
+        <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5">
           <ContextMenuItem onClick={() => onExpandAll(item)}>
             {t("expandAll")}
           </ContextMenuItem>
@@ -138,7 +138,7 @@ export function ExplorerTreeItem({
             {content}
           </Link>
         </ContextMenuTrigger>
-        <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5 shadow-lg">
+        <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5">
           <ContextMenuItem onClick={() => onOpenTab?.(item.href!)}>
             {t("open")}
           </ContextMenuItem>
@@ -159,7 +159,7 @@ export function ExplorerTreeItem({
       <ContextMenuTrigger asChild>
         <div>{content}</div>
       </ContextMenuTrigger>
-      <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5 shadow-lg">
+      <ContextMenuContent className="ide-dropdown w-44 rounded-sm border border-border bg-popover p-0.5">
         <ContextMenuItem onClick={() => copyPath(key)}>
           {t("copyPath")}
         </ContextMenuItem>

--- a/apps/web/src/components/ide/sidebar/explorer-tree-item.tsx
+++ b/apps/web/src/components/ide/sidebar/explorer-tree-item.tsx
@@ -69,7 +69,10 @@ export function ExplorerTreeItem({
               style={{ paddingLeft: `${depth * 12 + 4}px` }}
               type="button"
             >
-              <Chevron className="size-4 shrink-0 opacity-70" />
+              <Chevron
+                aria-hidden
+                className="size-4 shrink-0 text-muted-foreground/70"
+              />
               <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
               <span className="ml-1 truncate">{item.name}</span>
             </button>

--- a/apps/web/src/components/ide/sidebar/sidebar.tsx
+++ b/apps/web/src/components/ide/sidebar/sidebar.tsx
@@ -110,9 +110,15 @@ export const Sidebar = memo(function Sidebar({
             type="button"
           >
             {expanded.has("portfolio") ? (
-              <ChevronDown className="size-4 shrink-0 opacity-70" />
+              <ChevronDown
+                aria-hidden
+                className="size-4 shrink-0 text-muted-foreground/70"
+              />
             ) : (
-              <ChevronRight className="size-4 shrink-0 opacity-70" />
+              <ChevronRight
+                aria-hidden
+                className="size-4 shrink-0 text-muted-foreground/70"
+              />
             )}
             <span className="font-semibold text-[11px] uppercase tracking-wide">
               portfolio

--- a/apps/web/src/components/ide/sidebar/source-control-view.tsx
+++ b/apps/web/src/components/ide/sidebar/source-control-view.tsx
@@ -101,7 +101,7 @@ export const SourceControlView = memo(function SourceControlView({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="end"
-              className="ide-dropdown w-48 rounded-sm border border-border bg-popover p-0.5 shadow-lg"
+              className="ide-dropdown w-48 rounded-sm border border-border bg-popover p-0.5"
               side="right"
             >
               <DropdownMenuItem asChild>

--- a/apps/web/src/components/ide/sidebar/source-control-view.tsx
+++ b/apps/web/src/components/ide/sidebar/source-control-view.tsx
@@ -128,7 +128,10 @@ export const SourceControlView = memo(function SourceControlView({
               "cursor-not-allowed bg-muted/30 text-muted-foreground/80"
             )}
           >
-            <GitCommit className="size-4 shrink-0 opacity-60" />
+            <GitCommit
+                aria-hidden
+                className="size-4 shrink-0 text-muted-foreground/60"
+              />
             <span className="truncate">{t("commitMessagePlaceholder")}</span>
           </div>
           <div className="flex items-center gap-1">
@@ -180,7 +183,10 @@ export const SourceControlView = memo(function SourceControlView({
         {/* Branch + View on GitHub - compact single row */}
         <div className="flex items-center justify-between gap-2 border-border border-t px-2 py-1.5">
           <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-            <GitBranch className="size-3.5 shrink-0 opacity-70" />
+            <GitBranch
+                aria-hidden
+                className="size-3.5 shrink-0 text-muted-foreground/70"
+              />
             <span className="truncate font-medium">main</span>
           </div>
           <Tooltip>

--- a/apps/web/src/components/shared/language-selector.tsx
+++ b/apps/web/src/components/shared/language-selector.tsx
@@ -56,7 +56,7 @@ export function LanguageSelector() {
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        className="ide-dropdown min-w-[8rem] rounded-sm border border-border bg-popover p-0.5 shadow-lg"
+        className="ide-dropdown min-w-[8rem] rounded-sm border border-border bg-popover p-0.5"
         sideOffset={4}
       >
         <DropdownMenuRadioGroup onValueChange={handleChange} value={locale}>

--- a/apps/web/src/components/shared/theme-selector.tsx
+++ b/apps/web/src/components/shared/theme-selector.tsx
@@ -41,7 +41,7 @@ export function ThemeSelector() {
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="end"
-        className="ide-dropdown min-w-[8rem] rounded-sm border border-border bg-popover p-0.5 shadow-lg"
+        className="ide-dropdown min-w-[8rem] rounded-sm border border-border bg-popover p-0.5"
         sideOffset={4}
       >
         <DropdownMenuRadioGroup

--- a/apps/web/src/components/shared/theme-selector.tsx
+++ b/apps/web/src/components/shared/theme-selector.tsx
@@ -9,7 +9,6 @@ import {
 } from "@portfolio/ui";
 import { Palette } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useTheme } from "next-themes";
 import {
   THEME_PRESETS,
   type ThemePreset,
@@ -18,14 +17,9 @@ import {
 
 export function ThemeSelector() {
   const { preset, setPreset } = useThemePreset();
-  const { resolvedTheme } = useTheme();
   const t = useTranslations("ide");
-  const tTheme = useTranslations("theme");
 
-  const isDark = resolvedTheme === "dark";
-  const variantLabel =
-    preset === "default" ? "" : ` ${isDark ? tTheme("dark") : tTheme("light")}`;
-  const displayName = `${t(`themePreset_${preset}`)}${variantLabel}`;
+  const displayName = t(`themePreset_${preset}`);
 
   return (
     <DropdownMenu>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -74,6 +74,8 @@
   --shadow-opacity: var(--shadow-opacity);
   --color-shadow-color: var(--shadow-color);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-overlay: var(--overlay);
+  --color-overlay-strong: var(--overlay-strong);
 }
 
 /* Default theme: Vercel */
@@ -140,6 +142,8 @@
   --spacing: 0.25rem;
   --scrollbar-thumb: oklch(0.5 0 0 / 0.2);
   --scrollbar-thumb-hover: oklch(0.4 0 0 / 0.4);
+  --overlay: oklch(0 0 0 / 0.5);
+  --overlay-strong: oklch(0 0 0 / 0.8);
 
   /* Depth: light glow top + dark shadow bottom (raised elements) */
   --shadow-elevation-sm:
@@ -219,6 +223,8 @@
   --spacing: 0.25rem;
   --scrollbar-thumb: oklch(0.6 0 0 / 0.3);
   --scrollbar-thumb-hover: oklch(0.7 0 0 / 0.5);
+  --overlay: oklch(0 0 0 / 0.6);
+  --overlay-strong: oklch(0 0 0 / 0.85);
 
   /* Depth: stronger for dark mode - brighter top highlight, visible shadow */
   --shadow-elevation-sm:

--- a/apps/web/src/styles/ide/ide.css
+++ b/apps/web/src/styles/ide/ide.css
@@ -47,9 +47,10 @@
   --syntax-tag: oklch(0.55 0.2 25);
   --syntax-attribute: oklch(0.55 0.22 300);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.55 0.18 145);
-  --terminal-host: oklch(0.55 0.2 250);
-  --terminal-path: oklch(0.55 0.22 300);
+  /* Terminal matches syntax: user=string, host=type, path=keyword */
+  --terminal-user: var(--syntax-string);
+  --terminal-host: var(--syntax-type);
+  --terminal-path: var(--syntax-keyword);
   --terminal-output: var(--muted-foreground);
   --terminal-error: var(--destructive);
 }
@@ -64,9 +65,9 @@
   --syntax-tag: oklch(0.7 0.18 25);
   --syntax-attribute: oklch(0.75 0.15 300);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.75 0.18 145);
-  --terminal-host: oklch(0.7 0.18 250);
-  --terminal-path: oklch(0.75 0.15 300);
+  --terminal-user: var(--syntax-string);
+  --terminal-host: var(--syntax-type);
+  --terminal-path: var(--syntax-keyword);
   --terminal-output: var(--muted-foreground);
   --terminal-error: var(--destructive);
 }
@@ -110,11 +111,6 @@
   --syntax-tag: oklch(0.5 0.2 25);
   --syntax-attribute: oklch(0.45 0.22 300);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.45 0.18 145);
-  --terminal-host: oklch(0.45 0.2 250);
-  --terminal-path: oklch(0.45 0.22 300);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 .dark[data-theme="catppuccin"] {
@@ -152,9 +148,6 @@
   --syntax-tag: oklch(0.7 0.18 25);
   --syntax-attribute: oklch(0.78 0.15 300);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.75 0.18 145);
-  --terminal-host: oklch(0.7 0.18 250);
-  --terminal-path: oklch(0.78 0.15 300);
 }
 
 :root:not(.dark)[data-theme="violet-bloom"] {
@@ -200,11 +193,6 @@
   --syntax-tag: oklch(0.629 0.1902 23.0704);
   --syntax-attribute: oklch(0.5445 0.1903 259.4848);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.7459 0.1483 156.4499);
-  --terminal-host: oklch(0.5828 0.1809 259.7276);
-  --terminal-path: oklch(0.5393 0.2713 286.7462);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 .dark[data-theme="violet-bloom"] {
@@ -249,11 +237,6 @@
   --syntax-tag: oklch(0.7106 0.1661 22.2162);
   --syntax-attribute: oklch(0.6132 0.2294 291.7437);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.8003 0.1821 151.711);
-  --terminal-host: oklch(0.6691 0.1569 260.1063);
-  --terminal-path: oklch(0.6132 0.2294 291.7437);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 :root:not(.dark)[data-theme="caffeine"] {
@@ -298,11 +281,6 @@
   --syntax-tag: oklch(0.6271 0.1936 33.339);
   --syntax-attribute: oklch(0.3499 0.0685 40.8288);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.5828 0.1809 259.7276);
-  --terminal-host: oklch(0.4341 0.0392 41.9938);
-  --terminal-path: oklch(0.4338 0.0437 41.6746);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 .dark[data-theme="caffeine"] {
@@ -347,11 +325,6 @@
   --syntax-tag: oklch(0.6271 0.1936 33.339);
   --syntax-attribute: oklch(0.4882 0.2172 264.3763);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.9247 0.0524 66.1732);
-  --terminal-host: oklch(0.4882 0.2172 264.3763);
-  --terminal-path: oklch(0.9245 0.0533 67.0855);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 :root:not(.dark)[data-theme="mono"] {
@@ -420,11 +393,6 @@
   --syntax-tag: oklch(0.583 0.2387 28.4765);
   --syntax-attribute: oklch(0.5486 0 0);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.5486 0 0);
-  --terminal-host: oklch(0.2046 0 0);
-  --terminal-path: oklch(0.5555 0 0);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 .dark[data-theme="mono"] {
@@ -493,11 +461,6 @@
   --syntax-tag: oklch(0.7022 0.1892 22.2279);
   --syntax-attribute: oklch(0.709 0 0);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.709 0 0);
-  --terminal-host: oklch(0.9851 0 0);
-  --terminal-path: oklch(0.5555 0 0);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 :root:not(.dark)[data-theme="deep-purple"] {
@@ -582,11 +545,6 @@
   --syntax-tag: oklch(0.6356 0.2082 25.3782);
   --syntax-attribute: oklch(0.4865 0.2423 291.8661);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.6356 0.1398 156.1492);
-  --terminal-host: oklch(0.7216 0.1282 217.8676);
-  --terminal-path: oklch(0.4865 0.2423 291.8661);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 .dark[data-theme="deep-purple"] {
@@ -671,11 +629,6 @@
   --syntax-tag: oklch(0.6356 0.2082 25.3782);
   --syntax-attribute: oklch(0.6083 0.2172 297.1153);
   --syntax-punctuation: var(--muted-foreground);
-  --terminal-user: oklch(0.7801 0.1859 154.5892);
-  --terminal-host: oklch(0.7741 0.1272 215.0981);
-  --terminal-path: oklch(0.6083 0.2172 297.1153);
-  --terminal-output: var(--muted-foreground);
-  --terminal-error: var(--destructive);
 }
 
 /* Terminal panel - uses theme background, text colors adapt */

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -16,7 +16,7 @@ const badgeVariants = cva(
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+          "border-transparent bg-destructive text-destructive-foreground focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -29,7 +29,7 @@ function CommandDialog({
   return (
     <Dialog.Root {...props}>
       <Dialog.Portal>
-        <Dialog.Overlay className="data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in" />
+        <Dialog.Overlay className="data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-overlay-strong backdrop-blur-sm data-[state=closed]:animate-out data-[state=open]:animate-in" />
         <Dialog.Content className="data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 w-[calc(100vw-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-lg border bg-popover p-0 shadow-[var(--shadow-elevation-lg)] duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg">
           <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:text-xs">
             {children}
@@ -45,7 +45,7 @@ function CommandInput({
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
-    <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <div className="flex items-center border-b border-border px-3" cmdk-input-wrapper="">
       <Search className="mr-2 size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         className={cn(

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -27,7 +27,7 @@ function ContextMenuContent({
     <ContextMenuPrimitive.Portal>
       <ContextMenuPrimitive.Content
         className={cn(
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-elevation-md)] data-[state=closed]:animate-out data-[state=open]:animate-in",
           className
         )}
         data-slot="context-menu-content"

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -40,7 +40,7 @@ function DropdownMenuContent({
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         className={cn(
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-elevation-md)] data-[state=closed]:animate-out data-[state=open]:animate-in",
           className
         )}
         data-slot="dropdown-menu-content"
@@ -229,7 +229,7 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuPrimitive.SubContent
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-elevation-lg)] data-[state=closed]:animate-out data-[state=open]:animate-in",
         className
       )}
       data-slot="dropdown-menu-sub-content"

--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -31,7 +31,7 @@ function HoverCardContent({
       <HoverCardPrimitive.Content
         align={align}
         className={cn(
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-elevation-md)] outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in",
           className
         )}
         data-slot="hover-card-content"

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -29,7 +29,7 @@ function PopoverContent({
       <PopoverPrimitive.Content
         align={align}
         className={cn(
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-elevation-md)] outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in",
           className
         )}
         data-slot="popover-content"

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -62,7 +62,7 @@ function SelectContent({
       <SelectPrimitive.Content
         align={align}
         className={cn(
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-[var(--shadow-elevation-md)] data-[state=closed]:animate-out data-[state=open]:animate-in",
           position === "popper" &&
             "data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
           className

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -35,7 +35,7 @@ function SheetOverlay({
   return (
     <SheetPrimitive.Overlay
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-overlay data-[state=closed]:animate-out data-[state=open]:animate-in",
         className
       )}
       data-slot="sheet-overlay"
@@ -59,7 +59,7 @@ function SheetContent({
       <SheetOverlay />
       <SheetPrimitive.Content
         className={cn(
-          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-[var(--shadow-elevation-lg)] transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&


### PR DESCRIPTION
Integrate shadcn theming across components and match terminal colors to syntax highlighting.

This PR ensures consistent theming by:
- Replacing hardcoded shadows with theme-aware elevation variables for floating UI components.
- Introducing theme-aware overlay variables for `Sheet` and `CommandDialog`.
- Aligning `CommandInput` border and `Badge` destructive text with theme variables.
- Removing redundant shadows from IDE dropdowns.
- Updating terminal color variables to reference syntax highlighting variables, ensuring the terminal prompt and output follow each theme's code highlighting.

---
<p><a href="https://cursor.com/agents/bc-0c45c3fe-3a84-4731-a839-2b84ba48b201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c45c3fe-3a84-4731-a839-2b84ba48b201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

