### PR TITLE
Sync commit button layout

### DIFF
--- a/apps/web/src/components/ide/layout/ide-layout.tsx
+++ b/apps/web/src/components/ide/layout/ide-layout.tsx
@@ -154,8 +154,8 @@ export function IdeLayout({ children }: IdeLayoutProps) {
                 {layout.sidebarView === "sourceControl" ? (
                   <SourceControlView
                     commits={commits}
-                    isRefreshing={isRefreshing}
-                    onRefresh={fetchCommits}
+                    isSyncing={isRefreshing}
+                    onSync={fetchCommits}
                   />
                 ) : (
                   <Sidebar onOpenTab={editor.openTab} pathname={pathname} />
@@ -231,9 +231,9 @@ export function IdeLayout({ children }: IdeLayoutProps) {
                   <SourceControlView
                     commits={commits}
                     fullWidth
-                    isRefreshing={isRefreshing}
+                    isSyncing={isRefreshing}
                     onClose={() => layout.setMobileSidebarView(null)}
-                    onRefresh={fetchCommits}
+                    onSync={fetchCommits}
                   />
                 ) : layout.mobileSidebarView === "explorer" ? (
                   <Sidebar

--- a/apps/web/src/components/ide/sidebar/source-control-view.tsx
+++ b/apps/web/src/components/ide/sidebar/source-control-view.tsx
@@ -30,10 +30,8 @@ interface SourceControlViewProps {
   commits?: GitCommitItem[];
   fullWidth?: boolean;
   hasStagedChanges?: boolean;
-  isRefreshing?: boolean;
   isSyncing?: boolean;
   onClose?: () => void;
-  onRefresh?: () => void;
   onSync?: () => void;
 }
 
@@ -41,10 +39,8 @@ export const SourceControlView = memo(function SourceControlView({
   commits = MOCK_COMMITS,
   fullWidth = false,
   hasStagedChanges = false,
-  isRefreshing = false,
   isSyncing = false,
   onClose,
-  onRefresh,
   onSync,
 }: SourceControlViewProps) {
   const t = useTranslations("ide");
@@ -74,23 +70,6 @@ export const SourceControlView = memo(function SourceControlView({
               <X className="size-4" />
             </Button>
           )}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label="Refresh"
-                className="size-6 rounded p-0"
-                onClick={onRefresh}
-                size="icon-sm"
-                type="button"
-                variant="ghost"
-              >
-                <RefreshCw
-                  className={cn("size-3.5", isRefreshing && "animate-spin")}
-                />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Refresh</TooltipContent>
-          </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/apps/web/src/components/ide/sidebar/source-control-view.tsx
+++ b/apps/web/src/components/ide/sidebar/source-control-view.tsx
@@ -31,8 +31,10 @@ interface SourceControlViewProps {
   fullWidth?: boolean;
   hasStagedChanges?: boolean;
   isRefreshing?: boolean;
+  isSyncing?: boolean;
   onClose?: () => void;
   onRefresh?: () => void;
+  onSync?: () => void;
 }
 
 export const SourceControlView = memo(function SourceControlView({
@@ -40,8 +42,10 @@ export const SourceControlView = memo(function SourceControlView({
   fullWidth = false,
   hasStagedChanges = false,
   isRefreshing = false,
+  isSyncing = false,
   onClose,
   onRefresh,
+  onSync,
 }: SourceControlViewProps) {
   const t = useTranslations("ide");
   const displayCommits = commits.length > 0 ? commits : MOCK_COMMITS;
@@ -87,6 +91,23 @@ export const SourceControlView = memo(function SourceControlView({
             </TooltipTrigger>
             <TooltipContent side="bottom">Refresh</TooltipContent>
           </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label={t("syncChanges")}
+                className="size-6 rounded p-0"
+                onClick={onSync}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+              >
+                <RefreshCw
+                  className={cn("size-3.5", isSyncing && "animate-spin")}
+                />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{t("syncChanges")}</TooltipContent>
+          </Tooltip>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -120,30 +141,19 @@ export const SourceControlView = memo(function SourceControlView({
       </div>
 
       <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Commit message + buttons - VS Code style */}
+        {/* Commit message + button - VS Code style (sync is in header) */}
         <div className="flex flex-col gap-2 border-border border-b px-2 py-2">
-          <div className="flex items-center gap-1.5">
-            <div
-              className={cn(
-                "flex min-h-[28px] min-w-0 flex-1 items-center gap-1.5 rounded px-2 py-1.5 text-[13px] ring-1 ring-border/50 ring-inset",
-                "cursor-not-allowed bg-muted/30 text-muted-foreground/80"
-              )}
-            >
-              <GitCommit
-                aria-hidden
-                className="size-4 shrink-0 text-muted-foreground/60"
-              />
-              <span className="truncate">{t("commitMessagePlaceholder")}</span>
-            </div>
-            <Button
-              className="h-7 shrink-0 text-[11px]"
-              disabled
-              size="sm"
-              variant="outline"
-            >
-              <RefreshCw className="size-3.5" />
-              {t("syncChanges")}
-            </Button>
+          <div
+            className={cn(
+              "flex min-h-[72px] min-w-0 items-start gap-1.5 rounded px-2 py-2 text-[13px] ring-1 ring-border/50 ring-inset",
+              "cursor-not-allowed bg-muted/30 text-muted-foreground/80"
+            )}
+          >
+            <GitCommit
+              aria-hidden
+              className="mt-0.5 size-4 shrink-0 text-muted-foreground/60"
+            />
+            <span className="truncate">{t("commitMessagePlaceholder")}</span>
           </div>
           <Button
             className="h-7 w-full text-[11px]"

--- a/apps/web/src/components/ide/sidebar/source-control-view.tsx
+++ b/apps/web/src/components/ide/sidebar/source-control-view.tsx
@@ -122,30 +122,21 @@ export const SourceControlView = memo(function SourceControlView({
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Commit message + buttons - VS Code style */}
         <div className="flex flex-col gap-2 border-border border-b px-2 py-2">
-          <div
-            className={cn(
-              "flex min-h-[28px] items-center gap-1.5 rounded px-2 py-1.5 text-[13px] ring-1 ring-border/50 ring-inset",
-              "cursor-not-allowed bg-muted/30 text-muted-foreground/80"
-            )}
-          >
-            <GitCommit
+          <div className="flex items-center gap-1.5">
+            <div
+              className={cn(
+                "flex min-h-[28px] min-w-0 flex-1 items-center gap-1.5 rounded px-2 py-1.5 text-[13px] ring-1 ring-border/50 ring-inset",
+                "cursor-not-allowed bg-muted/30 text-muted-foreground/80"
+              )}
+            >
+              <GitCommit
                 aria-hidden
                 className="size-4 shrink-0 text-muted-foreground/60"
               />
-            <span className="truncate">{t("commitMessagePlaceholder")}</span>
-          </div>
-          <div className="flex items-center gap-1">
+              <span className="truncate">{t("commitMessagePlaceholder")}</span>
+            </div>
             <Button
-              className="h-7 flex-1 text-[11px]"
-              disabled
-              size="sm"
-              variant="secondary"
-            >
-              <GitCommit className="size-3.5" />
-              {t("commit")}
-            </Button>
-            <Button
-              className="h-7 flex-1 text-[11px]"
+              className="h-7 shrink-0 text-[11px]"
               disabled
               size="sm"
               variant="outline"
@@ -154,6 +145,15 @@ export const SourceControlView = memo(function SourceControlView({
               {t("syncChanges")}
             </Button>
           </div>
+          <Button
+            className="h-7 w-full text-[11px]"
+            disabled
+            size="sm"
+            variant="secondary"
+          >
+            <GitCommit className="size-3.5" />
+            {t("commit")}
+          </Button>
         </div>
 
         {/* Scrollable sections - STAGED (when present), CHANGES */}


### PR DESCRIPTION
Adjust layout of source control view to place the sync button next to the input and make the commit button full width.

---
<p><a href="https://cursor.com/agents/bc-fb489650-d0a7-4f53-8a17-c2a7d019b70f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb489650-d0a7-4f53-8a17-c2a7d019b70f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

