### PR TITLE
Source control menu appearance

### DIFF
--- a/apps/web/src/components/ide/sidebar/source-control-view.tsx
+++ b/apps/web/src/components/ide/sidebar/source-control-view.tsx
@@ -3,10 +3,6 @@
 import {
   Button,
   cn,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -15,7 +11,6 @@ import {
   ExternalLink,
   GitBranch,
   GitCommit,
-  MoreHorizontal,
   RefreshCw,
   X,
 } from "lucide-react";
@@ -87,35 +82,6 @@ export const SourceControlView = memo(function SourceControlView({
             </TooltipTrigger>
             <TooltipContent side="bottom">{t("syncChanges")}</TooltipContent>
           </Tooltip>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                aria-label={t("moreActions")}
-                className="size-6 rounded p-0"
-                size="icon-sm"
-                type="button"
-                variant="ghost"
-              >
-                <MoreHorizontal className="size-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="ide-dropdown w-48 rounded-sm border border-border bg-popover p-0.5"
-              side="right"
-            >
-              <DropdownMenuItem asChild>
-                <a
-                  href={`${PORTFOLIO_REPO_URL}/commits/main`}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <ExternalLink className="size-3.5" />
-                  {t("viewOnGitHub")}
-                </a>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
         </div>
       </div>
 


### PR DESCRIPTION
Remove the `...` overflow menu from the source control header because it only contained a redundant "View on GitHub" action.

---
<p><a href="https://cursor.com/agents/bc-453ac0ae-a7cb-462b-a349-bb7040871cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-453ac0ae-a7cb-462b-a349-bb7040871cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

