### PR TITLE
Locale switcher closing

### DIFF
--- a/apps/web/src/components/internationalization/locale-switcher.tsx
+++ b/apps/web/src/components/internationalization/locale-switcher.tsx
@@ -3,6 +3,7 @@
 import { config, type Locale, localeToFlagEmoji } from "@repo/i18n/config";
 import { Languages } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
+import { useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -29,9 +30,15 @@ export function LocaleSwitcher() {
   const locale = useLocale() as Locale;
   const pathname = useLocalePathname();
   const t = useTranslations("localeSwitcher");
+  const [open, setOpen] = useState(false);
+
+  const handleLocaleChange = (value: Locale) => {
+    setOpen(false);
+    updateLocale(value, pathname);
+  };
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <Tooltip>
         <TooltipTrigger asChild>
           <DropdownMenuTrigger
@@ -56,7 +63,7 @@ export function LocaleSwitcher() {
           <DropdownMenuLabel>{t("selectLanguage")}</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuRadioGroup
-            onValueChange={(value) => updateLocale(value as Locale, pathname)}
+            onValueChange={(value) => handleLocaleChange(value as Locale)}
             value={locale}
           >
             {locales.map((loc) => (


### PR DESCRIPTION
Close the locale switcher immediately after a locale is selected to prevent it from staying open until redirect.

---
<p><a href="https://cursor.com/agents/bc-061f9d16-52ab-4249-856e-e915da7dc9ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-061f9d16-52ab-4249-856e-e915da7dc9ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

