### PR TITLE
Commit history refresh button

### DIFF
--- a/apps/web/src/components/ide/sidebar/source-control-view.tsx
+++ b/apps/web/src/components/ide/sidebar/source-control-view.tsx
@@ -12,7 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import useSWR from "swr";
 import { CollapsibleSection } from "@/components/ide/sidebar/collapsible-section";
 import { CommitHistoryItem } from "@/components/ide/sidebar/commit-history-item";
@@ -27,7 +27,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import type { Commit } from "@/consts/ide-constants";
 import { REPO_URL } from "@/consts/ide-constants";
-import { getCommitsAction } from "@/lib/actions/github";
+import {
+  getCommitsAction,
+  revalidateCommitsAction,
+} from "@/lib/actions/github";
 import { IDE_DROPDOWN_CONTENT_CLASS } from "@/lib/ide-dropdown";
 import { cn } from "@/lib/utils";
 
@@ -41,12 +44,30 @@ export function SourceControlView({
   onClose,
 }: SourceControlViewProps) {
   const t = useTranslations("ide");
-  const [spinKey, setSpinKey] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const { data: commits = [], isLoading } = useSWR<Commit[]>(
-    "github-commits",
-    getCommitsAction
-  );
+  const lastRefreshRef = useRef(0);
+  const {
+    data: commits = [],
+    isLoading,
+    mutate,
+  } = useSWR<Commit[]>("github-commits", getCommitsAction);
+
+  const REFRESH_COOLDOWN_MS = 5000;
+  const handleRefreshCommitHistory = useCallback(async () => {
+    const now = Date.now();
+    if (now - lastRefreshRef.current < REFRESH_COOLDOWN_MS) {
+      return;
+    }
+    lastRefreshRef.current = now;
+    setIsRefreshing(true);
+    try {
+      await revalidateCommitsAction();
+      await mutate();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [mutate]);
 
   return (
     <div
@@ -115,9 +136,10 @@ export function SourceControlView({
             </DropdownMenuContent>
           </DropdownMenu>
           <Button
-            aria-label={t("syncChanges")}
+            aria-label={t("refreshCommitHistory")}
             className="size-6 rounded p-0"
-            onClick={() => setSpinKey((k: number) => k + 1)}
+            disabled={isRefreshing}
+            onClick={handleRefreshCommitHistory}
             size="icon-sm"
             type="button"
             variant="ghost"
@@ -125,9 +147,8 @@ export function SourceControlView({
             <RefreshCw
               className={cn(
                 "size-3.5",
-                spinKey > 0 && "animate-[spin_0.6s_linear_1]"
+                isRefreshing && "animate-[spin_0.6s_linear_infinite]"
               )}
-              key={spinKey}
             />
           </Button>
           {onClose && (

--- a/apps/web/src/lib/actions/github.ts
+++ b/apps/web/src/lib/actions/github.ts
@@ -8,6 +8,7 @@ export async function getCommitsAction() {
 }
 
 /** Invalidates the cached commit history so the next fetch gets fresh data */
-export function revalidateCommitsAction() {
+// biome-ignore lint/suspicious/useAwait: Server Actions must be async
+export async function revalidateCommitsAction() {
   revalidateTag("github-commits");
 }

--- a/apps/web/src/lib/actions/github.ts
+++ b/apps/web/src/lib/actions/github.ts
@@ -10,5 +10,5 @@ export async function getCommitsAction() {
 /** Invalidates the cached commit history so the next fetch gets fresh data */
 // biome-ignore lint/suspicious/useAwait: Server Actions must be async
 export async function revalidateCommitsAction() {
-  revalidateTag("github-commits");
+  revalidateTag("github-commits", "max");
 }

--- a/apps/web/src/lib/actions/github.ts
+++ b/apps/web/src/lib/actions/github.ts
@@ -1,7 +1,13 @@
 "use server";
 
+import { revalidateTag } from "next/cache";
 import { getGitHubCommits } from "@/lib/github";
 
 export async function getCommitsAction() {
   return await getGitHubCommits();
+}
+
+/** Invalidates the cached commit history so the next fetch gets fresh data */
+export function revalidateCommitsAction() {
+  revalidateTag("github-commits");
 }

--- a/packages/i18n/translations/en.json
+++ b/packages/i18n/translations/en.json
@@ -157,6 +157,7 @@
     "changes": "Changes",
     "stagedChanges": "Staged Changes",
     "commitHistory": "Commit History",
+    "refreshCommitHistory": "Refresh commit history",
     "syncChanges": "Sync Changes",
     "moreActions": "More Actions",
     "pull": "Pull",

--- a/packages/i18n/translations/es.json
+++ b/packages/i18n/translations/es.json
@@ -157,6 +157,7 @@
     "changes": "Cambios",
     "stagedChanges": "Cambios preparados",
     "commitHistory": "Historial de commits",
+    "refreshCommitHistory": "Actualizar historial de commits",
     "syncChanges": "Sincronizar cambios",
     "moreActions": "Más acciones",
     "pull": "Extraer",


### PR DESCRIPTION
Add a refresh button to the source control view to manually revalidate and fetch the latest commit history.

---
<p><a href="https://cursor.com/agents/bc-1a64097b-634a-4631-bd11-333aa0e36791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a64097b-634a-4631-bd11-333aa0e36791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

