### PR TITLE
feat(web): replace lucide icons with lucide-animated where available

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "fumadocs-mdx": "^14.2.8",
     "fumadocs-ui": "^16.6.7",
     "lucide-react": "^0.546.0",
+    "motion": "^12.34.4",
     "next": "^16.1.6",
     "next-intl": "^4.8.3",
     "next-themes": "^0.4.6",

--- a/apps/web/src/app/[locale]/error.tsx
+++ b/apps/web/src/app/[locale]/error.tsx
@@ -2,8 +2,8 @@
 
 import { useTranslations } from "next-intl";
 import { useEffect } from "react";
-import { LocaleLink } from "@/modules/i18n/routing";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { LocaleLink } from "@/modules/i18n/routing";
 
 export default function Error({
   error,
@@ -21,17 +21,14 @@ export default function Error({
   return (
     <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 px-4">
       <h1 className="font-medium text-foreground text-lg">{t("title")}</h1>
-      <p className="text-muted-foreground/80 text-center text-sm">
+      <p className="text-center text-muted-foreground/80 text-sm">
         {t("description")}
       </p>
       <div className="flex gap-3">
         <Button onClick={reset} variant="default">
           {t("retry")}
         </Button>
-        <LocaleLink
-          className={buttonVariants({ variant: "outline" })}
-          href="/"
-        >
+        <LocaleLink className={buttonVariants({ variant: "outline" })} href="/">
           {t("home")}
         </LocaleLink>
       </div>

--- a/apps/web/src/components/home/social-nav.tsx
+++ b/apps/web/src/components/home/social-nav.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { FileText, Github, Linkedin, Twitter } from "lucide-react";
+import { FileTextIcon } from "@/components/ui/file-text";
+import { GithubIcon } from "@/components/ui/github";
+import { LinkedinIcon } from "@/components/ui/linkedin";
+import { TwitterIcon } from "@/components/ui/twitter";
 import { socialLinks } from "@/consts/social-links";
 import { cn } from "@/lib/utils";
 
 const icons = {
-  github: Github,
-  twitter: Twitter,
-  linkedin: Linkedin,
-  fileText: FileText,
+  github: GithubIcon,
+  twitter: TwitterIcon,
+  linkedin: LinkedinIcon,
+  fileText: FileTextIcon,
 } as const;
 
 export function SocialNav() {
@@ -27,7 +30,10 @@ export function SocialNav() {
             rel="noopener noreferrer"
             target="_blank"
           >
-            <Icon className="size-3.5 transition-transform duration-200 group-hover:scale-110 sm:size-4" />
+            <Icon
+              className="transition-transform duration-200 group-hover:scale-110"
+              size={16}
+            />
             <span className="text-xs sm:text-sm">{link.text}</span>
           </a>
         );

--- a/apps/web/src/components/ide/editor/breadcrumbs.tsx
+++ b/apps/web/src/components/ide/editor/breadcrumbs.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { ChevronRight, Code, Eye } from "lucide-react";
+import { Code } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { navItems } from "@/components/ide/config";
+import { ChevronRightIcon } from "@/components/ui/chevron-right";
+import { EyeIcon } from "@/components/ui/eye";
 import { matchNavItem } from "@/lib/ide/breadcrumb";
 import { cn } from "@/lib/utils";
 import { useIdeStore } from "@/stores/ide-store";
@@ -33,9 +35,10 @@ export function Breadcrumbs({ pathname }: BreadcrumbsProps) {
           return (
             <span className="flex items-center gap-1" key={key}>
               {i > 0 && (
-                <ChevronRight
+                <ChevronRightIcon
                   aria-hidden
-                  className="size-3 shrink-0 text-muted-foreground/50"
+                  className="shrink-0 text-muted-foreground/50"
+                  size={12}
                 />
               )}
               <span
@@ -62,7 +65,7 @@ export function Breadcrumbs({ pathname }: BreadcrumbsProps) {
           onClick={() => setViewMode("preview")}
           type="button"
         >
-          <Eye className="size-3.5 shrink-0" />
+          <EyeIcon className="shrink-0" size={14} />
           {t("preview")}
         </button>
         <button

--- a/apps/web/src/components/ide/editor/editor-content-context-menu.tsx
+++ b/apps/web/src/components/ide/editor/editor-content-context-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Code, Copy, Eye } from "lucide-react";
+import { Code } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ViewMode } from "@/components/ide/shared/view-mode";
 import {
@@ -10,6 +10,8 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { CopyIcon } from "@/components/ui/copy";
+import { EyeIcon } from "@/components/ui/eye";
 
 interface EditorContentContextMenuProps {
   children: React.ReactNode;
@@ -33,7 +35,7 @@ export function EditorContentContextMenu({
         {onCopy && (
           <>
             <ContextMenuItem onClick={onCopy}>
-              <Copy className="mr-1.5 size-3.5" />
+              <CopyIcon className="mr-1.5" size={14} />
               {t("copyContent")}
             </ContextMenuItem>
             <ContextMenuSeparator />
@@ -43,7 +45,7 @@ export function EditorContentContextMenu({
           className={viewMode === "preview" ? "bg-muted/50" : undefined}
           onClick={() => onViewModeChange("preview")}
         >
-          <Eye className="size-3.5" />
+          <EyeIcon size={14} />
           {t("preview")}
         </ContextMenuItem>
         <ContextMenuItem

--- a/apps/web/src/components/ide/editor/editor-tab-item.tsx
+++ b/apps/web/src/components/ide/editor/editor-tab-item.tsx
@@ -2,9 +2,9 @@
 
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { FileIcon } from "@/components/ide/sidebar/file-icon";
+import { XIcon } from "@/components/ui/x";
 import { cn } from "@/lib/utils";
 import { LocaleLink } from "@/modules/i18n/routing";
 
@@ -93,7 +93,7 @@ export function EditorTabItem({
         }}
         type="button"
       >
-        <X className="size-3.5" />
+        <XIcon size={14} />
       </button>
     </div>
   );
@@ -152,7 +152,7 @@ export function EditorTabItemStatic({
         }}
         type="button"
       >
-        <X className="size-3.5" />
+        <XIcon size={14} />
       </button>
     </div>
   );

--- a/apps/web/src/components/ide/layout/activity-bar-button.tsx
+++ b/apps/web/src/components/ide/layout/activity-bar-button.tsx
@@ -3,10 +3,14 @@
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+type IconComponent =
+  | LucideIcon
+  | React.ComponentType<{ className?: string; size?: number }>;
+
 interface ActivityBarButtonProps {
   active?: boolean;
   ariaLabel: string;
-  icon: LucideIcon;
+  icon: IconComponent;
   onClick: () => void;
 }
 
@@ -26,7 +30,7 @@ export function ActivityBarButton({
       onClick={onClick}
       type="button"
     >
-      <Icon className="size-5" />
+      <Icon className="size-5" size={20} />
     </button>
   );
 }

--- a/apps/web/src/components/ide/layout/activity-bar.tsx
+++ b/apps/web/src/components/ide/layout/activity-bar.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { GitBranch, PanelLeft, Terminal } from "lucide-react";
+import { PanelLeft } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { ActivityBarButton } from "@/components/ide/layout/activity-bar-button";
 import { SettingsMenu } from "@/components/ide/layout/settings-menu";
+import { GitBranchIcon } from "@/components/ui/git-branch";
+import { TerminalIcon } from "@/components/ui/terminal";
 import { useIdeStore } from "@/stores/ide-store";
 
 export function ActivityBar() {
@@ -31,7 +33,7 @@ export function ActivityBar() {
       <ActivityBarButton
         active={sidebarOpen && sidebarView === "sourceControl"}
         ariaLabel={t("sourceControl")}
-        icon={GitBranch}
+        icon={GitBranchIcon}
         onClick={() => {
           setSidebarView("sourceControl");
           if (!sidebarOpen) {
@@ -42,7 +44,7 @@ export function ActivityBar() {
       <ActivityBarButton
         active={terminalOpen}
         ariaLabel={t("terminal")}
-        icon={Terminal}
+        icon={TerminalIcon}
         onClick={toggleTerminal}
       />
       <div className="mt-auto">

--- a/apps/web/src/components/ide/layout/mobile-activity-bar.tsx
+++ b/apps/web/src/components/ide/layout/mobile-activity-bar.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { GitBranch, PanelLeft, Terminal } from "lucide-react";
+import { PanelLeft } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { GitBranchIcon } from "@/components/ui/git-branch";
+import { TerminalIcon } from "@/components/ui/terminal";
 import { cn } from "@/lib/utils";
 import { useIdeStore } from "@/stores/ide-store";
 
@@ -28,7 +30,7 @@ export function MobileActivityBar() {
         onClick={() => setMobileSidebarView("sourceControl")}
         type="button"
       >
-        <GitBranch className="size-5 shrink-0" />
+        <GitBranchIcon className="shrink-0" size={20} />
         <span className="text-xs">{t("sourceShort")}</span>
       </button>
       <button
@@ -42,7 +44,7 @@ export function MobileActivityBar() {
         onClick={toggleTerminal}
         type="button"
       >
-        <Terminal className="size-5 shrink-0" />
+        <TerminalIcon className="shrink-0" size={20} />
         <span className="text-xs">{t("terminal")}</span>
       </button>
     </div>

--- a/apps/web/src/components/ide/layout/settings-menu.tsx
+++ b/apps/web/src/components/ide/layout/settings-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { config, type Locale, localeToFlagEmoji } from "@repo/i18n/config";
-import { Command, ExternalLink, Languages, Settings } from "lucide-react";
+import { Command, ExternalLink } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import {
   DropdownMenu,
@@ -15,6 +15,8 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { LanguagesIcon } from "@/components/ui/languages";
+import { SettingsIcon } from "@/components/ui/settings";
 import { REPO_URL } from "@/consts/ide-constants";
 import { IDE_DROPDOWN_CONTENT_CLASS } from "@/lib/ide-dropdown";
 import { cn } from "@/lib/utils";
@@ -35,7 +37,7 @@ export function SettingsMenu() {
         aria-label={t("settings")}
         className="flex size-10 cursor-pointer items-center justify-center text-sidebar-foreground/60 transition-colors hover:text-sidebar-primary"
       >
-        <Settings className="size-5" />
+        <SettingsIcon size={20} />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
@@ -58,7 +60,7 @@ export function SettingsMenu() {
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuLabel className="flex items-center gap-2">
-            <Languages className="size-3.5" />
+            <LanguagesIcon size={14} />
             {tLocale("selectLanguage")}
           </DropdownMenuLabel>
           <DropdownMenuRadioGroup

--- a/apps/web/src/components/ide/layout/status-bar.tsx
+++ b/apps/web/src/components/ide/layout/status-bar.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { GitBranch, Moon, Play, Sun, Terminal } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 import { memo, useCallback, useEffect, useState } from "react";
 import { navItems } from "@/components/ide/config";
 import { LocaleSwitcher } from "@/components/internationalization/locale-switcher";
+import { GitBranchIcon } from "@/components/ui/git-branch";
+import { MoonIcon } from "@/components/ui/moon";
+import { PlayIcon } from "@/components/ui/play";
+import { SunIcon } from "@/components/ui/sun";
+import { TerminalIcon } from "@/components/ui/terminal";
 import { REPO_URL } from "@/consts/ide-constants";
 import { useThemeTransition } from "@/hooks/use-theme-transition";
 import { matchNavItem } from "@/lib/ide/breadcrumb";
@@ -60,9 +64,9 @@ export const StatusBar = memo(function StatusBar({
       />
     );
   } else if (isDark) {
-    themeIcon = <Sun className="size-3.5 shrink-0" />;
+    themeIcon = <SunIcon className="shrink-0" size={14} />;
   } else {
-    themeIcon = <Moon className="size-3.5 shrink-0" />;
+    themeIcon = <MoonIcon className="shrink-0" size={14} />;
   }
 
   const navItem = matchNavItem(pathname, navItems);
@@ -85,7 +89,7 @@ export const StatusBar = memo(function StatusBar({
             onClick={onFocusSourceControl}
             type="button"
           >
-            <GitBranch className="size-3.5 shrink-0" />
+            <GitBranchIcon className="shrink-0" size={14} />
             <span className="hidden sm:inline">main</span>
           </button>
         ) : (
@@ -96,7 +100,7 @@ export const StatusBar = memo(function StatusBar({
             rel="noopener noreferrer"
             target="_blank"
           >
-            <GitBranch className="size-3.5 shrink-0" />
+            <GitBranchIcon className="shrink-0" size={14} />
             <span className="hidden sm:inline">main</span>
           </a>
         )}
@@ -116,7 +120,7 @@ export const StatusBar = memo(function StatusBar({
           }}
           type="button"
         >
-          <Play className="size-3.5 shrink-0" />
+          <PlayIcon className="shrink-0" size={14} />
           <span className="hidden sm:inline">{t("preview")}</span>
         </button>
         <button
@@ -128,7 +132,7 @@ export const StatusBar = memo(function StatusBar({
           onClick={toggleTerminal}
           type="button"
         >
-          <Terminal className="size-3.5 shrink-0" />
+          <TerminalIcon className="shrink-0" size={14} />
           <span className="hidden sm:inline">{t("terminal")}</span>
         </button>
         <span className="hidden tabular-nums sm:inline">{t("lnCol")}</span>

--- a/apps/web/src/components/ide/layout/title-bar.tsx
+++ b/apps/web/src/components/ide/layout/title-bar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Minus, Square, X } from "lucide-react";
+import { Minus, Square } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { XIcon } from "@/components/ui/x";
 import { cn } from "@/lib/utils";
 
 interface TitleBarProps {
@@ -39,7 +40,10 @@ export function TitleBar({
             }}
             type="button"
           >
-            <X className="size-[8px] stroke-[2.5] text-[#4d0000] opacity-0 transition-opacity group-hover/dots:opacity-100" />
+            <XIcon
+              className="text-[#4d0000] opacity-0 transition-opacity group-hover/dots:opacity-100"
+              size={8}
+            />
           </button>
           <button
             aria-label={tIde("minimize")}

--- a/apps/web/src/components/ide/sidebar/collapsible-section.tsx
+++ b/apps/web/src/components/ide/sidebar/collapsible-section.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
+import { ChevronDownIcon } from "@/components/ui/chevron-down";
+import { ChevronRightIcon } from "@/components/ui/chevron-right";
 
 interface CollapsibleSectionProps {
   children: React.ReactNode;
@@ -15,7 +16,7 @@ export function CollapsibleSection({
   title,
 }: CollapsibleSectionProps) {
   const [open, setOpen] = useState(defaultOpen);
-  const Chevron = open ? ChevronDown : ChevronRight;
+  const Chevron = open ? ChevronDownIcon : ChevronRightIcon;
 
   return (
     <div className="flex flex-col">
@@ -26,7 +27,8 @@ export function CollapsibleSection({
       >
         <Chevron
           aria-hidden
-          className="size-3.5 shrink-0 text-muted-foreground/70"
+          className="shrink-0 text-muted-foreground/70"
+          size={14}
         />
         {title}
       </button>

--- a/apps/web/src/components/ide/sidebar/commit-history-item.tsx
+++ b/apps/web/src/components/ide/sidebar/commit-history-item.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { GitBranch, Github } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
+import { GitBranchIcon } from "@/components/ui/git-branch";
+import { GithubIcon } from "@/components/ui/github";
 import {
   HoverCard,
   HoverCardContent,
@@ -75,11 +76,11 @@ export function CommitHistoryItem({ commit }: CommitHistoryItemProps) {
             )}
             <div className="flex flex-wrap items-center gap-1.5">
               <span className="inline-flex items-center gap-1 rounded border border-border/60 bg-muted/30 px-1.5 py-0.5 font-medium text-[10px] text-primary">
-                <GitBranch className="size-3" />
+                <GitBranchIcon size={12} />
                 main
               </span>
               <span className="inline-flex items-center gap-1 rounded border border-border/60 bg-muted/20 px-1.5 py-0.5 font-medium text-[10px] text-muted-foreground">
-                <GitBranch className="size-3" />
+                <GitBranchIcon size={12} />
                 origin/main
               </span>
             </div>
@@ -91,7 +92,7 @@ export function CommitHistoryItem({ commit }: CommitHistoryItemProps) {
             rel="noopener noreferrer"
             target="_blank"
           >
-            <Github className="size-3.5" />
+            <GithubIcon size={14} />
             {shaShort} · {t("viewOnGitHub")}
           </a>
         </div>

--- a/apps/web/src/components/ide/sidebar/explorer-tree-item.tsx
+++ b/apps/web/src/components/ide/sidebar/explorer-tree-item.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { ChevronDown, ChevronRight, Folder, FolderOpen } from "lucide-react";
+import { Folder } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { TreeItem } from "@/components/ide/config";
 import { FileIcon } from "@/components/ide/sidebar/file-icon";
+import { ChevronDownIcon } from "@/components/ui/chevron-down";
+import { ChevronRightIcon } from "@/components/ui/chevron-right";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -11,6 +13,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { FolderOpenIcon } from "@/components/ui/folder-open";
 import { LocaleLink } from "@/modules/i18n/routing";
 
 function isFileActive(pathname: string, href?: string): boolean {
@@ -53,8 +56,8 @@ export function ExplorerTreeItem({
   if (item.type === "folder") {
     const key = `${path}/${item.name}`;
     const isOpen = expanded.has(key);
-    const Chevron = isOpen ? ChevronDown : ChevronRight;
-    const FolderIcon = isOpen ? FolderOpen : Folder;
+    const Chevron = isOpen ? ChevronDownIcon : ChevronRightIcon;
+    const FolderIcon = isOpen ? FolderOpenIcon : Folder;
 
     return (
       <div key={key}>
@@ -68,9 +71,17 @@ export function ExplorerTreeItem({
             >
               <Chevron
                 aria-hidden
-                className="size-4 shrink-0 text-muted-foreground/70"
+                className="shrink-0 text-muted-foreground/70"
+                size={16}
               />
-              <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
+              {isOpen ? (
+                <FolderOpenIcon
+                  className="shrink-0 text-muted-foreground"
+                  size={16}
+                />
+              ) : (
+                <FolderIcon className="size-4 shrink-0 text-muted-foreground" />
+              )}
               <span className="ml-1 truncate">{item.name}</span>
             </button>
           </ContextMenuTrigger>

--- a/apps/web/src/components/ide/terminal/terminal-panel.tsx
+++ b/apps/web/src/components/ide/terminal/terminal-panel.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { GripHorizontal, PanelBottomClose, Play, Terminal } from "lucide-react";
+import { PanelBottomClose } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MockTerminal } from "@/components/ide/terminal/mock-terminal";
+import { GripHorizontalIcon } from "@/components/ui/grip-horizontal";
+import { PlayIcon } from "@/components/ui/play";
+import { TerminalIcon } from "@/components/ui/terminal";
 import { cn } from "@/lib/utils";
 import { useIdeStore } from "@/stores/ide-store";
 
@@ -88,16 +91,17 @@ export function TerminalPanel() {
         role="separator"
         tabIndex={0}
       >
-        <GripHorizontal
+        <GripHorizontalIcon
           className={cn(
-            "size-3.5 text-muted-foreground transition-opacity duration-150",
+            "text-muted-foreground transition-opacity duration-150",
             showResizeHandle ? "opacity-100" : "opacity-0"
           )}
+          size={14}
         />
       </div>
       <div className="flex h-8 shrink-0 items-center justify-between border-border border-b bg-muted/50 px-2 shadow-(--shadow-elevation-sm)">
         <div className="flex items-center gap-2">
-          <Terminal className="size-4 text-muted-foreground" />
+          <TerminalIcon className="text-muted-foreground" size={16} />
           <span className="font-medium text-[11px] text-foreground">
             {t("terminal")}
           </span>
@@ -117,7 +121,7 @@ export function TerminalPanel() {
             }
             type="button"
           >
-            <Play className="size-4" />
+            <PlayIcon size={16} />
           </button>
           <button
             aria-label={t("closePanel")}

--- a/apps/web/src/components/internationalization/locale-switcher.tsx
+++ b/apps/web/src/components/internationalization/locale-switcher.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { config, type Locale, localeToFlagEmoji } from "@repo/i18n/config";
-import { Languages } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import {
@@ -14,6 +13,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { LanguagesIcon } from "@/components/ui/languages";
 import { IDE_DROPDOWN_CONTENT_CLASS } from "@/lib/ide-dropdown";
 import { cn } from "@/lib/utils";
 import { updateLocale } from "@/modules/i18n/lib/update-locale";
@@ -38,7 +38,7 @@ export function LocaleSwitcher() {
         aria-label={t("selectLanguage")}
         className="flex cursor-pointer items-center gap-1 rounded px-1 py-0.5 text-muted-foreground/50 text-xs transition-colors duration-200 hover:text-foreground sm:text-sm [&_svg]:size-3.5"
       >
-        <Languages className="size-3.5 shrink-0" />
+        <LanguagesIcon className="shrink-0" size={14} />
         <span className="hidden sm:inline">{config.locales[locale].label}</span>
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/apps/web/src/components/projects/project-card-details.tsx
+++ b/apps/web/src/components/projects/project-card-details.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import type { GitHubRepo } from "@repo/github";
-import { ExternalLink, GitFork, Star } from "lucide-react";
+import { ExternalLink, Star } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { memo } from "react";
+import { GitForkIcon } from "@/components/ui/git-fork";
 import { languageColors } from "@/consts/language-colors";
 import { cn } from "@/lib/utils";
 
@@ -69,7 +70,7 @@ function ProjectCardDetailsInner({
           {repo.stargazers_count}
         </span>
         <span className="inline-flex items-center gap-0.5">
-          <GitFork className="size-3" />
+          <GitForkIcon size={12} />
           {repo.forks_count}
         </span>
       </div>

--- a/apps/web/src/components/projects/project-card.tsx
+++ b/apps/web/src/components/projects/project-card.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import type { GitHubRepo } from "@repo/github";
-import { GitFork, Star } from "lucide-react";
+import { Star } from "lucide-react";
 import { memo } from "react";
 import { ProjectCardDetails } from "@/components/projects/project-card-details";
+import { GitForkIcon } from "@/components/ui/git-fork";
 import {
   HoverCard,
   HoverCardContent,
@@ -119,7 +120,7 @@ function ProjectCardSummary({
           {repo.stargazers_count}
         </span>
         <span className="inline-flex items-center gap-0.5">
-          <GitFork className="size-3" />
+          <GitForkIcon size={12} />
           {repo.forks_count}
         </span>
       </div>

--- a/apps/web/src/components/projects/project-filters.tsx
+++ b/apps/web/src/components/projects/project-filters.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Search } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { memo } from "react";
 import { Input } from "@/components/ui/input";
+import { SearchIcon } from "@/components/ui/search";
 import {
   Select,
   SelectContent,
@@ -32,7 +32,10 @@ export const ProjectFilters = memo(function ProjectFilters({
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
       <div className="relative min-w-0 flex-1">
-        <Search className="absolute top-1/2 left-2.5 size-3 -translate-y-1/2 text-muted-foreground/60" />
+        <SearchIcon
+          className="absolute top-1/2 left-2.5 -translate-y-1/2 text-muted-foreground/60"
+          size={12}
+        />
         <Input
           className="h-8 w-full border-transparent bg-muted/25 pl-8 text-xs transition-colors placeholder:text-muted-foreground/50 focus:border-border focus:bg-transparent sm:text-sm"
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>

--- a/apps/web/src/components/projects/project-list.tsx
+++ b/apps/web/src/components/projects/project-list.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { GitHubRepo } from "@repo/github";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
   parseAsInteger,
@@ -16,6 +15,8 @@ import {
   type SortOption,
   sortOptions,
 } from "@/components/projects/project-filters";
+import { ChevronLeftIcon } from "@/components/ui/chevron-left";
+import { ChevronRightIcon } from "@/components/ui/chevron-right";
 
 const ITEMS_PER_PAGE = 5;
 
@@ -145,7 +146,7 @@ export const ProjectList = memo(function ProjectList({
             onClick={() => handlePageChange(currentPage - 1)}
             type="button"
           >
-            <ChevronLeft className="size-3.5" />
+            <ChevronLeftIcon size={14} />
             {t("prev")}
           </button>
           <span className="min-w-12 text-center text-muted-foreground/60 text-xs tabular-nums">
@@ -158,7 +159,7 @@ export const ProjectList = memo(function ProjectList({
             type="button"
           >
             {t("next")}
-            <ChevronRight className="size-3.5" />
+            <ChevronRightIcon size={14} />
           </button>
         </div>
       )}

--- a/apps/web/src/components/shared/pagination.tsx
+++ b/apps/web/src/components/shared/pagination.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { ChevronLeftIcon } from "@/components/ui/chevron-left";
+import { ChevronRightIcon } from "@/components/ui/chevron-right";
 import { LocaleLink } from "@/modules/i18n/routing";
 
 interface PaginationProps {
@@ -36,7 +37,7 @@ export function Pagination({
           className="inline-flex h-7 items-center gap-1 px-2 text-muted-foreground/70 text-xs transition-colors hover:text-foreground"
           href={prevHref}
         >
-          <ChevronLeft className="size-3" />
+          <ChevronLeftIcon size={12} />
           {t("prev")}
         </LocaleLink>
       ) : (
@@ -44,7 +45,7 @@ export function Pagination({
           aria-disabled
           className="inline-flex h-7 cursor-not-allowed items-center gap-1 px-2 text-muted-foreground/40 text-xs"
         >
-          <ChevronLeft className="size-3" />
+          <ChevronLeftIcon size={12} />
           {t("prev")}
         </span>
       )}
@@ -57,7 +58,7 @@ export function Pagination({
           href={nextHref}
         >
           {t("next")}
-          <ChevronRight className="size-3" />
+          <ChevronRightIcon size={12} />
         </LocaleLink>
       ) : (
         <span
@@ -65,7 +66,7 @@ export function Pagination({
           className="inline-flex h-7 cursor-not-allowed items-center gap-1 px-2 text-muted-foreground/40 text-xs"
         >
           {t("next")}
-          <ChevronRight className="size-3" />
+          <ChevronRightIcon size={12} />
         </span>
       )}
     </div>

--- a/apps/web/src/components/ui/check.tsx
+++ b/apps/web/src/components/ui/check.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface CheckIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface CheckIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    scale: 1,
+    transition: {
+      duration: 0.3,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    scale: [0.5, 1],
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const CheckIcon = forwardRef<CheckIconHandle, CheckIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="M4 12 9 17L20 6"
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+CheckIcon.displayName = "CheckIcon";
+
+export { CheckIcon };

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -1,5 +1,5 @@
 import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
-import { CheckIcon } from "lucide-react";
+import { CheckIcon } from "@/components/ui/check";
 
 import { cn } from "@/lib/utils";
 
@@ -17,7 +17,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
         data-slot="checkbox-indicator"
       >
-        <CheckIcon />
+        <CheckIcon size={14} />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/apps/web/src/components/ui/chevron-down.tsx
+++ b/apps/web/src/components/ui/chevron-down.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Transition } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ChevronDownIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ChevronDownIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
+  duration: 0.5,
+};
+
+const ChevronDownIcon = forwardRef<ChevronDownIconHandle, ChevronDownIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="m6 9 6 6 6-6"
+            transition={DEFAULT_TRANSITION}
+            variants={{
+              normal: { y: 0 },
+              animate: { y: [0, 2, 0] },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+ChevronDownIcon.displayName = "ChevronDownIcon";
+
+export { ChevronDownIcon };

--- a/apps/web/src/components/ui/chevron-left.tsx
+++ b/apps/web/src/components/ui/chevron-left.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Transition } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ChevronLeftIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ChevronLeftIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
+  duration: 0.5,
+};
+
+const ChevronLeftIcon = forwardRef<ChevronLeftIconHandle, ChevronLeftIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="m15 18-6-6 6-6"
+            transition={DEFAULT_TRANSITION}
+            variants={{
+              normal: { x: 0 },
+              animate: { x: [0, -2, 0] },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+ChevronLeftIcon.displayName = "ChevronLeftIcon";
+
+export { ChevronLeftIcon };

--- a/apps/web/src/components/ui/chevron-right.tsx
+++ b/apps/web/src/components/ui/chevron-right.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { Transition } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ChevronRightIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ChevronRightIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
+  duration: 0.5,
+};
+
+const ChevronRightIcon = forwardRef<
+  ChevronRightIconHandle,
+  ChevronRightIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseEnter?.(e);
+      } else {
+        controls.start("animate");
+      }
+    },
+    [controls, onMouseEnter]
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseLeave?.(e);
+      } else {
+        controls.start("normal");
+      }
+    },
+    [controls, onMouseLeave]
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        fill="none"
+        height={size}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        width={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <motion.path
+          animate={controls}
+          d="m9 18 6-6-6-6"
+          transition={DEFAULT_TRANSITION}
+          variants={{
+            normal: { x: 0 },
+            animate: { x: [0, 2, 0] },
+          }}
+        />
+      </svg>
+    </div>
+  );
+});
+
+ChevronRightIcon.displayName = "ChevronRightIcon";
+
+export { ChevronRightIcon };

--- a/apps/web/src/components/ui/chevron-up.tsx
+++ b/apps/web/src/components/ui/chevron-up.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Transition } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ChevronUpIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ChevronUpIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
+  duration: 0.5,
+};
+
+const ChevronUpIcon = forwardRef<ChevronUpIconHandle, ChevronUpIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="m18 15-6-6-6 6"
+            transition={DEFAULT_TRANSITION}
+            variants={{
+              normal: { y: 0 },
+              animate: { y: [0, -2, 0] },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+ChevronUpIcon.displayName = "ChevronUpIcon";
+
+export { ChevronUpIcon };

--- a/apps/web/src/components/ui/command.tsx
+++ b/apps/web/src/components/ui/command.tsx
@@ -15,7 +15,8 @@ import {
   InputGroup,
   InputGroupAddon,
 } from "@/components/ui/input-group"
-import { SearchIcon, CheckIcon } from "lucide-react"
+import { CheckIcon } from "@/components/ui/check"
+import { SearchIcon } from "@/components/ui/search"
 
 function Command({
   className,
@@ -86,7 +87,7 @@ function CommandInput({
           {...props}
         />
         <InputGroupAddon>
-          <SearchIcon className="size-4 shrink-0 opacity-50" />
+          <SearchIcon className="shrink-0 opacity-50" size={16} />
         </InputGroupAddon>
       </InputGroup>
     </div>
@@ -166,7 +167,7 @@ function CommandItem({
       {...props}
     >
       {children}
-      <CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
+      <CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" size={16} />
     </CommandPrimitive.Item>
   )
 }

--- a/apps/web/src/components/ui/copy.tsx
+++ b/apps/web/src/components/ui/copy.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import type { Transition } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface CopyIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface CopyIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  type: "spring",
+  stiffness: 160,
+  damping: 17,
+  mass: 1,
+};
+
+const CopyIcon = forwardRef<CopyIconHandle, CopyIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.rect
+            animate={controls}
+            height="14"
+            rx="2"
+            ry="2"
+            transition={DEFAULT_TRANSITION}
+            variants={{
+              normal: { translateY: 0, translateX: 0 },
+              animate: { translateY: -3, translateX: -3 },
+            }}
+            width="14"
+            x="8"
+            y="8"
+          />
+          <motion.path
+            animate={controls}
+            d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+            transition={DEFAULT_TRANSITION}
+            variants={{
+              normal: { x: 0, y: 0 },
+              animate: { x: 3, y: 3 },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+CopyIcon.displayName = "CopyIcon";
+
+export { CopyIcon };

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -5,7 +5,7 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { XIcon } from "@/components/ui/x"
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
@@ -72,7 +72,7 @@ function DialogContent({
               />
             }
           >
-            <XIcon />
+            <XIcon size={16} />
             <span className="sr-only">{closeAriaLabel}</span>
           </DialogPrimitive.Close>
         )}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
-import { CheckIcon, ChevronRightIcon } from "lucide-react";
+import { CheckIcon } from "@/components/ui/check";
+import { ChevronRightIcon } from "@/components/ui/chevron-right";
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 
@@ -121,7 +122,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <ChevronRightIcon className="ml-auto" />
+      <ChevronRightIcon className="ml-auto" size={16} />
     </MenuPrimitive.SubmenuTrigger>
   );
 }
@@ -175,7 +176,7 @@ function DropdownMenuCheckboxItem({
         data-slot="dropdown-menu-checkbox-item-indicator"
       >
         <MenuPrimitive.CheckboxItemIndicator>
-          <CheckIcon />
+          <CheckIcon size={16} />
         </MenuPrimitive.CheckboxItemIndicator>
       </span>
       {children}
@@ -215,7 +216,7 @@ function DropdownMenuRadioItem({
         data-slot="dropdown-menu-radio-item-indicator"
       >
         <MenuPrimitive.RadioItemIndicator>
-          <CheckIcon />
+          <CheckIcon size={16} />
         </MenuPrimitive.RadioItemIndicator>
       </span>
       {children}

--- a/apps/web/src/components/ui/eye.tsx
+++ b/apps/web/src/components/ui/eye.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface EyeIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface EyeIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const EyeIcon = forwardRef<EyeIconHandle, EyeIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"
+            style={{ originY: "50%" }}
+            transition={{ duration: 0.4, ease: "easeInOut" }}
+            variants={{
+              normal: { scaleY: 1, opacity: 1 },
+              animate: { scaleY: [1, 0.1, 1], opacity: [1, 0.3, 1] },
+            }}
+          />
+          <motion.circle
+            animate={controls}
+            cx="12"
+            cy="12"
+            r="3"
+            transition={{ duration: 0.4, ease: "easeInOut" }}
+            variants={{
+              normal: { scale: 1, opacity: 1 },
+              animate: { scale: [1, 0.3, 1], opacity: [1, 0.3, 1] },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+EyeIcon.displayName = "EyeIcon";
+
+export { EyeIcon };

--- a/apps/web/src/components/ui/file-text.tsx
+++ b/apps/web/src/components/ui/file-text.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type React from "react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface FileTextIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface FileTextIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const FILE_TEXT = forwardRef<FileTextIconHandle, FileTextIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          initial="normal"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          variants={{
+            normal: { scale: 1 },
+            animate: {
+              scale: 1.05,
+              transition: {
+                duration: 0.3,
+                ease: "easeOut",
+              },
+            },
+          }}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+          <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+
+          <motion.path
+            d="M10 9H8"
+            stroke="currentColor"
+            strokeWidth="2"
+            variants={{
+              normal: {
+                pathLength: 1,
+                x1: 8,
+                x2: 10,
+              },
+              animate: {
+                pathLength: [1, 0, 1],
+                x1: [8, 10, 8],
+                x2: [10, 10, 10],
+                transition: {
+                  duration: 0.7,
+                  delay: 0.3,
+                },
+              },
+            }}
+          />
+          <motion.path
+            d="M16 13H8"
+            stroke="currentColor"
+            strokeWidth="2"
+            variants={{
+              normal: {
+                pathLength: 1,
+                x1: 8,
+                x2: 16,
+              },
+              animate: {
+                pathLength: [1, 0, 1],
+                x1: [8, 16, 8],
+                x2: [16, 16, 16],
+                transition: {
+                  duration: 0.7,
+                  delay: 0.5,
+                },
+              },
+            }}
+          />
+          <motion.path
+            d="M16 17H8"
+            stroke="currentColor"
+            strokeWidth="2"
+            variants={{
+              normal: {
+                pathLength: 1,
+                x1: 8,
+                x2: 16,
+              },
+              animate: {
+                pathLength: [1, 0, 1],
+                x1: [8, 16, 8],
+                x2: [16, 16, 16],
+                transition: {
+                  duration: 0.7,
+                  delay: 0.7,
+                },
+              },
+            }}
+          />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+FILE_TEXT.displayName = "FileTextIcon";
+
+export { FILE_TEXT as FileTextIcon };

--- a/apps/web/src/components/ui/folder-open.tsx
+++ b/apps/web/src/components/ui/folder-open.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes, MouseEvent } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface FolderOpenIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface FolderOpenIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const VARIANTS: Variants = {
+  normal: { rotate: 0 },
+  animate: {
+    rotate: [0, -8, 6, -4, 0],
+    transition: {
+      ease: "easeInOut",
+      rotate: {
+        duration: 0.6,
+      },
+    },
+  },
+};
+
+const FolderOpenIcon = forwardRef<FolderOpenIconHandle, FolderOpenIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"
+            initial="normal"
+            style={{ transformOrigin: "12px 12px" }}
+            variants={VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+FolderOpenIcon.displayName = "FolderOpenIcon";
+
+export { FolderOpenIcon };

--- a/apps/web/src/components/ui/git-branch.tsx
+++ b/apps/web/src/components/ui/git-branch.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface GitBranchIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface GitBranchIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DURATION = 0.3;
+
+const CALCULATE_DELAY = (i: number) => {
+  if (i === 0) return 0.1;
+
+  return i * DURATION + 0.1;
+};
+
+const GitBranchIcon = forwardRef<GitBranchIconHandle, GitBranchIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.circle
+            animate={controls}
+            cx="18"
+            cy="6"
+            r="3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(0),
+              opacity: { delay: CALCULATE_DELAY(0) },
+            }}
+            variants={{
+              normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+              },
+            }}
+          />
+
+          <motion.line
+            animate={controls}
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(1),
+              opacity: { delay: CALCULATE_DELAY(1) },
+            }}
+            variants={{
+              normal: {
+                pathLength: 1,
+                pathOffset: 0,
+                opacity: 1,
+                transition: { delay: 0 },
+              },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+                pathOffset: [1, 0],
+              },
+            }}
+            x1="6"
+            x2="6"
+            y1="3"
+            y2="15"
+          />
+
+          <motion.circle
+            animate={controls}
+            cx="6"
+            cy="18"
+            r="3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(2),
+              opacity: { delay: CALCULATE_DELAY(2) },
+            }}
+            variants={{
+              normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+              },
+            }}
+          />
+
+          <motion.path
+            animate={controls}
+            d="M18 9a9 9 0 0 1-9 9"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(1),
+              opacity: { delay: CALCULATE_DELAY(1) },
+            }}
+            variants={{
+              normal: {
+                pathLength: 1,
+                pathOffset: 0,
+                opacity: 1,
+                transition: { delay: 0 },
+              },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+                pathOffset: [1, 0],
+              },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+GitBranchIcon.displayName = "GitBranchIcon";
+
+export { GitBranchIcon };

--- a/apps/web/src/components/ui/git-fork.tsx
+++ b/apps/web/src/components/ui/git-fork.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface GitForkIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface GitForkIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DURATION = 0.3;
+
+const CALCULATE_DELAY = (i: number) => {
+  if (i === 0) return 0.1;
+
+  return i * DURATION + 0.1;
+};
+
+const GitForkIcon = forwardRef<GitForkIconHandle, GitForkIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.circle
+            animate={controls}
+            cx="12"
+            cy="18"
+            r="3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(0),
+              opacity: { delay: CALCULATE_DELAY(0) },
+            }}
+            variants={{
+              normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+              },
+            }}
+          />
+
+          <motion.path
+            animate={controls}
+            d="M18 9v2c0 .6-.4 1-1 1H7c-.6 0-1-.4-1-1V9"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(1),
+              opacity: { delay: CALCULATE_DELAY(1) },
+            }}
+            variants={{
+              normal: {
+                pathLength: 1,
+                pathOffset: 0,
+                opacity: 1,
+                transition: { delay: 0 },
+              },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+                pathOffset: [1, 0],
+              },
+            }}
+          />
+
+          <motion.circle
+            animate={controls}
+            cx="6"
+            cy="6"
+            r="3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(2),
+              opacity: { delay: CALCULATE_DELAY(2) },
+            }}
+            variants={{
+              normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+              },
+            }}
+          />
+
+          <motion.circle
+            animate={controls}
+            cx="18"
+            cy="6"
+            r="3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(2),
+              opacity: { delay: CALCULATE_DELAY(2) },
+            }}
+            variants={{
+              normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+              },
+            }}
+          />
+
+          <motion.path
+            animate={controls}
+            d="M12 12v3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(1),
+              opacity: { delay: CALCULATE_DELAY(1) },
+            }}
+            variants={{
+              normal: {
+                pathLength: 1,
+                pathOffset: 0,
+                opacity: 1,
+                transition: { delay: 0 },
+              },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+                pathOffset: [1, 0],
+              },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+GitForkIcon.displayName = "GitForkIcon";
+
+export { GitForkIcon };

--- a/apps/web/src/components/ui/github.tsx
+++ b/apps/web/src/components/ui/github.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface GithubIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface GithubIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const BODY_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    scale: 1,
+    transition: {
+      duration: 0.3,
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    scale: [0.9, 1],
+    transition: {
+      duration: 0.4,
+    },
+  },
+};
+
+const TAIL_VARIANTS: Variants = {
+  normal: {
+    pathLength: 1,
+    rotate: 0,
+    transition: {
+      duration: 0.3,
+    },
+  },
+  draw: {
+    pathLength: [0, 1],
+    rotate: 0,
+    transition: {
+      duration: 0.5,
+    },
+  },
+  wag: {
+    pathLength: 1,
+    rotate: [0, -15, 15, -10, 10, -5, 5],
+    transition: {
+      duration: 2.5,
+      ease: "easeInOut",
+      repeat: Number.POSITIVE_INFINITY,
+    },
+  },
+};
+
+const GithubIcon = forwardRef<GithubIconHandle, GithubIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const bodyControls = useAnimation();
+    const tailControls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: async () => {
+          bodyControls.start("animate");
+          await tailControls.start("draw");
+          tailControls.start("wag");
+        },
+        stopAnimation: () => {
+          bodyControls.start("normal");
+          tailControls.start("normal");
+        },
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      async (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          bodyControls.start("animate");
+          await tailControls.start("draw");
+          tailControls.start("wag");
+        }
+      },
+      [bodyControls, onMouseEnter, tailControls]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          bodyControls.start("normal");
+          tailControls.start("normal");
+        }
+      },
+      [bodyControls, tailControls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={bodyControls}
+            d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"
+            initial="normal"
+            variants={BODY_VARIANTS}
+          />
+          <motion.path
+            animate={tailControls}
+            d="M9 18c-4.51 2-5-2-7-2"
+            initial="normal"
+            variants={TAIL_VARIANTS}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+GithubIcon.displayName = "GithubIcon";
+
+export { GithubIcon };

--- a/apps/web/src/components/ui/grip-horizontal.tsx
+++ b/apps/web/src/components/ui/grip-horizontal.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface GripHorizontalIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface GripHorizontalIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const CIRCLES = [
+  { cx: 5, cy: 9 },
+  { cx: 12, cy: 9 },
+  { cx: 19, cy: 9 },
+  { cx: 5, cy: 15 },
+  { cx: 12, cy: 15 },
+  { cx: 19, cy: 15 },
+];
+
+const VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: 0.25, ease: "easeOut" },
+  },
+  animate: (index: number) => {
+    const row = Math.floor(index / 3);
+    const col = index % 3;
+
+    const delay = col * 0.15 + row * 0.25;
+
+    return {
+      opacity: [1, 0.4, 1],
+      scale: [1, 0.85, 1],
+      transition: {
+        delay,
+        duration: 1,
+        ease: "easeInOut",
+      },
+    };
+  },
+};
+
+const GripHorizontalIcon = forwardRef<
+  GripHorizontalIconHandle,
+  GripHorizontalIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+  const isAnimatingRef = useRef(false);
+
+  const startAnimation = useCallback(async () => {
+    if (isAnimatingRef.current) return;
+    isAnimatingRef.current = true;
+    await controls.start("animate");
+    await controls.start("normal");
+    isAnimatingRef.current = false;
+  }, [controls]);
+
+  const stopAnimation = useCallback(async () => {
+    if (!isAnimatingRef.current) return;
+    await controls.start("normal");
+    isAnimatingRef.current = false;
+  }, [controls]);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return { startAnimation, stopAnimation };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) startAnimation();
+      onMouseEnter?.(e);
+    },
+    [startAnimation, onMouseEnter]
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isControlledRef.current) stopAnimation();
+      onMouseLeave?.(e);
+    },
+    [stopAnimation, onMouseLeave]
+  );
+
+  return (
+    <div
+      className={cn("inline-flex items-center justify-center", className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        fill="none"
+        height={size}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        width={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        {CIRCLES.map((circle, index) => (
+          <motion.circle
+            animate={controls}
+            custom={index}
+            cx={circle.cx}
+            cy={circle.cy}
+            initial="normal"
+            key={`${circle.cx}-${circle.cy}`}
+            r="1"
+            variants={VARIANTS}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+});
+
+GripHorizontalIcon.displayName = "GripHorizontalIcon";
+export { GripHorizontalIcon };

--- a/apps/web/src/components/ui/languages.tsx
+++ b/apps/web/src/components/ui/languages.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface LanguagesIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface LanguagesIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: { opacity: 1, pathLength: 1, pathOffset: 0 },
+  animate: (custom: number) => ({
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      opacity: { duration: 0.01, delay: custom * 0.1 },
+      pathLength: {
+        type: "spring",
+        duration: 0.5,
+        bounce: 0,
+        delay: custom * 0.1,
+      },
+    },
+  }),
+};
+
+const SVG_VARIANTS: Variants = {
+  normal: { opacity: 1 },
+  animate: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+      delayChildren: 0.2,
+    },
+  },
+};
+
+const LanguagesIcon = forwardRef<LanguagesIconHandle, LanguagesIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const svgControls = useAnimation();
+    const pathControls = useAnimation();
+
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => {
+          svgControls.start("animate");
+          pathControls.start("animate");
+        },
+        stopAnimation: () => {
+          svgControls.start("normal");
+          pathControls.start("normal");
+        },
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          svgControls.start("animate");
+          pathControls.start("animate");
+        }
+      },
+      [onMouseEnter, pathControls, svgControls]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          svgControls.start("normal");
+          pathControls.start("normal");
+        }
+      },
+      [svgControls, pathControls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={svgControls}
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          variants={SVG_VARIANTS}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={pathControls}
+            custom={3}
+            d="m5 8 6 6"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={pathControls}
+            custom={2}
+            d="m4 14 6-6 3-3"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={pathControls}
+            custom={1}
+            d="M2 5h12"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={pathControls}
+            custom={0}
+            d="M7 2h1"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={pathControls}
+            custom={3}
+            d="m22 22-5-10-5 10"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={pathControls}
+            custom={3}
+            d="M14 18h6"
+            variants={PATH_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+LanguagesIcon.displayName = "LanguagesIcon";
+
+export { LanguagesIcon };

--- a/apps/web/src/components/ui/linkedin.tsx
+++ b/apps/web/src/components/ui/linkedin.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface LinkedinIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface LinkedinIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: "linear",
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const RECT_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: "linear",
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const CIRCLE_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: "linear",
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const LinkedinIcon = forwardRef<LinkedinIconHandle, LinkedinIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const pathControls = useAnimation();
+    const rectControls = useAnimation();
+    const circleControls = useAnimation();
+
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => {
+          pathControls.start("animate");
+          rectControls.start("animate");
+          circleControls.start("animate");
+        },
+        stopAnimation: () => {
+          pathControls.start("normal");
+          rectControls.start("normal");
+          circleControls.start("normal");
+        },
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          pathControls.start("animate");
+          rectControls.start("animate");
+          circleControls.start("animate");
+        }
+      },
+      [circleControls, onMouseEnter, pathControls, rectControls]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          pathControls.start("normal");
+          rectControls.start("normal");
+          circleControls.start("normal");
+        }
+      },
+      [pathControls, rectControls, circleControls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={pathControls}
+            d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+          <motion.rect
+            animate={rectControls}
+            height="12"
+            initial="normal"
+            variants={RECT_VARIANTS}
+            width="4"
+            x="2"
+            y="9"
+          />
+          <motion.circle
+            animate={circleControls}
+            cx="4"
+            cy="4"
+            initial="normal"
+            r="2"
+            variants={CIRCLE_VARIANTS}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+LinkedinIcon.displayName = "LinkedinIcon";
+
+export { LinkedinIcon };

--- a/apps/web/src/components/ui/moon.tsx
+++ b/apps/web/src/components/ui/moon.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import type { Transition, Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface MoonIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface MoonIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SVG_VARIANTS: Variants = {
+  normal: {
+    rotate: 0,
+  },
+  animate: {
+    rotate: [0, -10, 10, -5, 5, 0],
+  },
+};
+
+const SVG_TRANSITION: Transition = {
+  duration: 1.2,
+  ease: "easeInOut",
+};
+
+const MoonIcon = forwardRef<MoonIconHandle, MoonIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          transition={SVG_TRANSITION}
+          variants={SVG_VARIANTS}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+MoonIcon.displayName = "MoonIcon";
+
+export { MoonIcon };

--- a/apps/web/src/components/ui/play.tsx
+++ b/apps/web/src/components/ui/play.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface PlayIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface PlayIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    x: 0,
+    rotate: 0,
+  },
+  animate: {
+    x: [0, -1, 2, 0],
+    rotate: [0, -10, 0, 0],
+    transition: {
+      duration: 0.5,
+      times: [0, 0.2, 0.5, 1],
+      stiffness: 260,
+      damping: 20,
+    },
+  },
+};
+
+const PlayIcon = forwardRef<PlayIconHandle, PlayIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.polygon
+            animate={controls}
+            points="6 3 20 12 6 21 6 3"
+            variants={PATH_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+PlayIcon.displayName = "PlayIcon";
+
+export { PlayIcon };

--- a/apps/web/src/components/ui/search.tsx
+++ b/apps/web/src/components/ui/search.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SearchIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SearchIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SearchIcon = forwardRef<SearchIconHandle, SearchIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          transition={{
+            duration: 1,
+            bounce: 0.3,
+          }}
+          variants={{
+            normal: { x: 0, y: 0 },
+            animate: {
+              x: [0, 0, -3, 0],
+              y: [0, -4, 0, 0],
+            },
+          }}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.3-4.3" />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+SearchIcon.displayName = "SearchIcon";
+
+export { SearchIcon };

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -2,7 +2,9 @@ import * as React from "react"
 import { Select as SelectPrimitive } from "@base-ui/react/select"
 
 import { cn } from "@/lib/utils"
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+import { CheckIcon } from "@/components/ui/check";
+import { ChevronDownIcon } from "@/components/ui/chevron-down";
+import { ChevronUpIcon } from "@/components/ui/chevron-up";
 
 const Select = SelectPrimitive.Root
 
@@ -47,7 +49,7 @@ function SelectTrigger({
       {children}
       <SelectPrimitive.Icon
         render={
-          <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4" />
+          <ChevronDownIcon className="text-muted-foreground pointer-events-none" size={16} />
         }
       />
     </SelectPrimitive.Trigger>
@@ -128,7 +130,7 @@ function SelectItem({
           <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
         }
       >
-        <CheckIcon className="pointer-events-none" />
+        <CheckIcon className="pointer-events-none" size={16} />
       </SelectPrimitive.ItemIndicator>
     </SelectPrimitive.Item>
   )
@@ -160,8 +162,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <ChevronUpIcon
-      />
+      <ChevronUpIcon size={16} />
     </SelectPrimitive.ScrollUpArrow>
   )
 }
@@ -179,8 +180,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <ChevronDownIcon
-      />
+      <ChevronDownIcon size={16} />
     </SelectPrimitive.ScrollDownArrow>
   )
 }

--- a/apps/web/src/components/ui/settings.tsx
+++ b/apps/web/src/components/ui/settings.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SettingsIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SettingsIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SettingsIcon = forwardRef<SettingsIconHandle, SettingsIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          transition={{ type: "spring", stiffness: 50, damping: 10 }}
+          variants={{
+            normal: {
+              rotate: 0,
+            },
+            animate: {
+              rotate: 180,
+            },
+          }}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+          <circle cx="12" cy="12" r="3" />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+SettingsIcon.displayName = "SettingsIcon";
+
+export { SettingsIcon };

--- a/apps/web/src/components/ui/sun.tsx
+++ b/apps/web/src/components/ui/sun.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SunIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SunIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: { opacity: 1 },
+  animate: (i: number) => ({
+    opacity: [0, 1],
+    transition: { delay: i * 0.1, duration: 0.3 },
+  }),
+};
+
+const SunIcon = forwardRef<SunIconHandle, SunIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle cx="12" cy="12" r="4" />
+          {[
+            "M12 2v2",
+            "m19.07 4.93-1.41 1.41",
+            "M20 12h2",
+            "m17.66 17.66 1.41 1.41",
+            "M12 20v2",
+            "m6.34 17.66-1.41 1.41",
+            "M2 12h2",
+            "m4.93 4.93 1.41 1.41",
+          ].map((d, index) => (
+            <motion.path
+              animate={controls}
+              custom={index + 1}
+              d={d}
+              key={d}
+              variants={PATH_VARIANTS}
+            />
+          ))}
+        </svg>
+      </div>
+    );
+  }
+);
+
+SunIcon.displayName = "SunIcon";
+
+export { SunIcon };

--- a/apps/web/src/components/ui/terminal.tsx
+++ b/apps/web/src/components/ui/terminal.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface TerminalIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface TerminalIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const LINE_VARIANTS: Variants = {
+  normal: { opacity: 1 },
+  animate: {
+    opacity: [1, 0, 1],
+    transition: {
+      duration: 0.8,
+      repeat: Number.POSITIVE_INFINITY,
+      ease: "linear",
+    },
+  },
+};
+
+const TerminalIcon = forwardRef<TerminalIconHandle, TerminalIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline points="4 17 10 11 4 5" />
+          <motion.line
+            animate={controls}
+            initial="normal"
+            variants={LINE_VARIANTS}
+            x1="12"
+            x2="20"
+            y1="19"
+            y2="19"
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+TerminalIcon.displayName = "TerminalIcon";
+
+export { TerminalIcon };

--- a/apps/web/src/components/ui/twitter.tsx
+++ b/apps/web/src/components/ui/twitter.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface TwitterIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface TwitterIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: "linear",
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const TwitterIcon = forwardRef<TwitterIconHandle, TwitterIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"
+            initial="normal"
+            variants={PATH_VARIANTS}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+TwitterIcon.displayName = "TwitterIcon";
+
+export { TwitterIcon };

--- a/apps/web/src/components/ui/x.tsx
+++ b/apps/web/src/components/ui/x.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface XIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface XIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+  },
+};
+
+const XIcon = forwardRef<XIconHandle, XIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="M18 6 6 18"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={controls}
+            d="m6 6 12 12"
+            transition={{ delay: 0.2 }}
+            variants={PATH_VARIANTS}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+XIcon.displayName = "XIcon";
+
+export { XIcon };

--- a/package.json
+++ b/package.json
@@ -40,10 +40,5 @@
       "pnpm dlx ultracite fix"
     ]
   },
-  "packageManager": "pnpm@10.30.3",
-  "pnpm": {
-    "overrides": {
-      "zod": "^4.3.6"
-    }
-  }
+  "packageManager": "pnpm@10.30.3"
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,10 @@
       "pnpm dlx ultracite fix"
     ]
   },
-  "packageManager": "pnpm@10.30.3"
+  "packageManager": "pnpm@10.30.3",
+  "pnpm": {
+    "overrides": {
+      "zod": "^4.3.6"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,9 @@ catalogs:
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
-    zod:
-      specifier: ^4.3.6
-      version: 4.3.6
+
+overrides:
+  zod: ^4.3.6
 
 importers:
 
@@ -27,7 +27,7 @@ importers:
         specifier: 'catalog:'
         version: 17.3.1
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@biomejs/biome':
@@ -122,13 +122,13 @@ importers:
         version: 17.3.1
       fumadocs-core:
         specifier: ^16.6.7
-        version: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        version: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: ^14.2.8
-        version: 14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: ^16.6.7
-        version: 16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
+        version: 16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
       lucide-react:
         specifier: ^0.546.0
         version: 0.546.0(react@19.2.4)
@@ -175,8 +175,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       zod:
-        specifier: 'catalog:'
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -229,7 +229,7 @@ importers:
         specifier: 'catalog:'
         version: 17.3.1
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@repo/config':
@@ -1017,7 +1017,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      zod: ^4.3.6
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -2088,7 +2088,7 @@ packages:
       arktype: ^2.1.0
       typescript: '>=5.0.0'
       valibot: ^1.0.0-beta.7 || ^1.0.0
-      zod: ^3.24.0 || ^4.0.0
+      zod: ^4.3.6
     peerDependenciesMeta:
       arktype:
         optional: true
@@ -2105,7 +2105,7 @@ packages:
       arktype: ^2.1.0
       typescript: '>=5.0.0'
       valibot: ^1.0.0-beta.7 || ^1.0.0
-      zod: ^3.24.0 || ^4.0.0
+      zod: ^4.3.6
     peerDependenciesMeta:
       arktype:
         optional: true
@@ -2909,7 +2909,7 @@ packages:
       react-dom: ^19.2.0
       react-router: 7.x.x
       waku: ^0.26.0 || ^0.27.0 || ^1.0.0
-      zod: 4.x.x
+      zod: ^4.3.6
     peerDependenciesMeta:
       '@mdx-js/mdx':
         optional: true
@@ -4606,10 +4606,7 @@ packages:
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
-      zod: ^3.25 || ^4
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+      zod: ^4.3.6
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -5384,7 +5381,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.3)
       ajv: 8.18.0
@@ -5401,8 +5398,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -7242,7 +7239,7 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76):
+  fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@orama/orama': 3.1.18
@@ -7277,18 +7274,18 @@ snapshots:
       next: 16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zod: 3.25.76
+      zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -7310,7 +7307,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
+  fumadocs-ui@16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
     dependencies:
       '@fumadocs/tailwind': 0.0.2(tailwindcss@4.2.1)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -7324,7 +7321,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       lucide-react: 0.575.0(react@19.2.4)
       motion: 12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8872,7 +8869,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.52.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
       commander: 14.0.3
@@ -8899,8 +8896,8 @@ snapshots:
       ts-morph: 26.0.0
       tsconfig-paths: 4.2.0
       validate-npm-package-name: 7.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@types/node'
@@ -9355,11 +9352,9 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}
+      zod: 4.3.6
 
   zod@4.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,9 @@ catalogs:
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
-
-overrides:
-  zod: ^4.3.6
+    zod:
+      specifier: ^4.3.6
+      version: 4.3.6
 
 importers:
 
@@ -27,7 +27,7 @@ importers:
         specifier: 'catalog:'
         version: 17.3.1
       zod:
-        specifier: ^4.3.6
+        specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
       '@biomejs/biome':
@@ -122,13 +122,13 @@ importers:
         version: 17.3.1
       fumadocs-core:
         specifier: ^16.6.7
-        version: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       fumadocs-mdx:
         specifier: ^14.2.8
-        version: 14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: ^16.6.7
-        version: 16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
+        version: 16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
       lucide-react:
         specifier: ^0.546.0
         version: 0.546.0(react@19.2.4)
@@ -175,8 +175,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: 'catalog:'
+        version: 3.25.76
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -229,7 +229,7 @@ importers:
         specifier: 'catalog:'
         version: 17.3.1
       zod:
-        specifier: ^4.3.6
+        specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
       '@repo/config':
@@ -1017,7 +1017,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^4.3.6
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -2088,7 +2088,7 @@ packages:
       arktype: ^2.1.0
       typescript: '>=5.0.0'
       valibot: ^1.0.0-beta.7 || ^1.0.0
-      zod: ^4.3.6
+      zod: ^3.24.0 || ^4.0.0
     peerDependenciesMeta:
       arktype:
         optional: true
@@ -2105,7 +2105,7 @@ packages:
       arktype: ^2.1.0
       typescript: '>=5.0.0'
       valibot: ^1.0.0-beta.7 || ^1.0.0
-      zod: ^4.3.6
+      zod: ^3.24.0 || ^4.0.0
     peerDependenciesMeta:
       arktype:
         optional: true
@@ -2909,7 +2909,7 @@ packages:
       react-dom: ^19.2.0
       react-router: 7.x.x
       waku: ^0.26.0 || ^0.27.0 || ^1.0.0
-      zod: ^4.3.6
+      zod: 4.x.x
     peerDependenciesMeta:
       '@mdx-js/mdx':
         optional: true
@@ -4606,7 +4606,10 @@ packages:
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
-      zod: ^4.3.6
+      zod: ^3.25 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -5381,7 +5384,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.3)
       ajv: 8.18.0
@@ -5398,8 +5401,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -7239,7 +7242,7 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@orama/orama': 3.1.18
@@ -7274,18 +7277,18 @@ snapshots:
       next: 16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zod: 4.3.6
+      zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -7307,7 +7310,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
+  fumadocs-ui@16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
     dependencies:
       '@fumadocs/tailwind': 0.0.2(tailwindcss@4.2.1)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -7321,7 +7324,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       lucide-react: 0.575.0(react@19.2.4)
       motion: 12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8869,7 +8872,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.52.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
       commander: 14.0.3
@@ -8896,8 +8899,8 @@ snapshots:
       ts-morph: 26.0.0
       tsconfig-paths: 4.2.0
       validate-npm-package-name: 7.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@types/node'
@@ -9352,9 +9355,11 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-to-json-schema@3.25.1(zod@4.3.6):
+  zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
-      zod: 4.3.6
+      zod: 3.25.76
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 9.1.7
       lint-staged:
         specifier: latest
-        version: 16.2.7
+        version: 16.3.1
       turbo:
         specifier: ^2.8.12
         version: 2.8.12
@@ -122,16 +122,19 @@ importers:
         version: 17.3.1
       fumadocs-core:
         specifier: ^16.6.7
-        version: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       fumadocs-mdx:
         specifier: ^14.2.8
-        version: 14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: ^16.6.7
-        version: 16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
+        version: 16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
       lucide-react:
         specifier: ^0.546.0
         version: 0.546.0(react@19.2.4)
+      motion:
+        specifier: ^12.34.4
+        version: 12.34.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: ^16.1.6
         version: 16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -173,7 +176,7 @@ importers:
         version: 1.4.0
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 3.25.76
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -2865,6 +2868,20 @@ packages:
       react-dom:
         optional: true
 
+  framer-motion@12.34.4:
+    resolution: {integrity: sha512-q1PwNhc1XJ3qYG7nc9+pEU5P3tnjB6Eh9vv5gGzy61nedDLB4+xk5peMCWhKM0Zn6sfhgunf/q9n0UgCoyKOBA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -3379,8 +3396,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  lint-staged@16.2.7:
-    resolution: {integrity: sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==}
+  lint-staged@16.3.1:
+    resolution: {integrity: sha512-bqvvquXzFBAlSbluugR4KXAe4XnO/QZcKVszpkBtqLWa2KEiVy8n6Xp38OeUbv/gOJOX4Vo9u5pFt/ADvbm42Q==}
     engines: {node: '>=20.17'}
     hasBin: true
 
@@ -3649,6 +3666,20 @@ packages:
       react-dom:
         optional: true
 
+  motion@12.34.4:
+    resolution: {integrity: sha512-J0cuDNRymNzE0M2WY8CFcbQuprHBZwY+iqADKGLLe6kQUVP4kBQ2l7Z6gWK7Zfrt5Wgxs+kCojj4qu7I4wxBIw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3665,10 +3696,6 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
-
-  nano-spawn@2.0.0:
-    resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
-    engines: {node: '>=20.17'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3884,11 +3911,6 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
-
-  pidtree@0.6.0:
-    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
-    engines: {node: '>=0.10'}
-    hasBin: true
 
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
@@ -7203,6 +7225,15 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  framer-motion@12.34.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 12.34.3
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fresh@2.0.0: {}
 
   fs-extra@11.3.3:
@@ -7211,7 +7242,7 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@orama/orama': 3.1.18
@@ -7246,18 +7277,18 @@ snapshots:
       next: 16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zod: 4.3.6
+      zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.8(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -7279,7 +7310,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
+  fumadocs-ui@16.6.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
     dependencies:
       '@fumadocs/tailwind': 0.0.2(tailwindcss@4.2.1)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -7293,7 +7324,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.546.0(react@19.2.4))(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       lucide-react: 0.575.0(react@19.2.4)
       motion: 12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -7706,14 +7737,13 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  lint-staged@16.2.7:
+  lint-staged@16.3.1:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
       micromatch: 4.0.8
-      nano-spawn: 2.0.0
-      pidtree: 0.6.0
       string-argv: 0.3.2
+      tinyexec: 1.0.2
       yaml: 2.8.2
 
   listr2@9.0.5:
@@ -8236,6 +8266,14 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  motion@12.34.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      framer-motion: 12.34.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   ms@2.1.3: {}
 
   msw@2.12.10(@types/node@20.19.35)(typescript@5.9.3):
@@ -8264,8 +8302,6 @@ snapshots:
       - '@types/node'
 
   mute-stream@2.0.0: {}
-
-  nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -8468,8 +8504,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
-
-  pidtree@0.6.0: {}
 
   pkce-challenge@5.0.1: {}
 


### PR DESCRIPTION
- Add 21 animated icon components via shadcn/lucide-animated registry
- Replace icons in UI components, project cards, IDE layout, sidebar, etc.
- Keep lucide-react for icons without animated variants (Star, Loader2, etc.)