### PR TITLE
Shadcn mcp base UI migration

### DIFF
--- a/apps/web/src/components/ui/context-menu.tsx
+++ b/apps/web/src/components/ui/context-menu.tsx
@@ -1,37 +1,73 @@
 "use client";
 
-import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
-import type * as React from "react";
+import React from "react";
+import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu";
 import { cn } from "@/lib/utils";
 
 function ContextMenu({
   ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+}: ContextMenuPrimitive.Root.Props) {
   return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
 }
 
 function ContextMenuTrigger({
+  asChild,
+  children,
   ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+}: ContextMenuPrimitive.Trigger.Props & {
+  asChild?: boolean;
+}) {
+  if (asChild && React.isValidElement(children)) {
+    return (
+      <ContextMenuPrimitive.Trigger
+        data-slot="context-menu-trigger"
+        render={(triggerProps) =>
+          React.cloneElement(
+            children as React.ReactElement<object>,
+            triggerProps as Record<string, unknown>
+          )
+        }
+        {...props}
+      />
+    );
+  }
   return (
-    <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
+    <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props}>
+      {children}
+    </ContextMenuPrimitive.Trigger>
   );
 }
 
 function ContextMenuContent({
   className,
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 0,
   ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+}: ContextMenuPrimitive.Popup.Props &
+  Pick<
+    ContextMenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
   return (
     <ContextMenuPrimitive.Portal>
-      <ContextMenuPrimitive.Content
-        className={cn(
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-28 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-sm border bg-popover p-0.5 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
-          className
-        )}
-        data-slot="context-menu-content"
-        {...props}
-      />
+      <ContextMenuPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        className="isolate z-50 outline-none"
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <ContextMenuPrimitive.Popup
+          className={cn(
+            "data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-28 origin-(--transform-origin) overflow-hidden rounded-sm border bg-popover p-0.5 text-popover-foreground shadow-md data-closed:animate-out data-open:animate-in",
+            className
+          )}
+          data-slot="context-menu-content"
+          {...props}
+        />
+      </ContextMenuPrimitive.Positioner>
     </ContextMenuPrimitive.Portal>
   );
 }
@@ -41,7 +77,7 @@ function ContextMenuItem({
   inset,
   variant = "default",
   ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+}: ContextMenuPrimitive.Item.Props & {
   inset?: boolean;
   variant?: "default" | "destructive";
 }) {

--- a/apps/web/src/components/ui/hover-card.tsx
+++ b/apps/web/src/components/ui/hover-card.tsx
@@ -1,44 +1,99 @@
 "use client";
 
 import * as React from "react";
-/** biome-ignore lint/performance/noNamespaceImport: shadcn/radix pattern */
-import { HoverCard as HoverCardPrimitive } from "radix-ui";
-
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 import { cn } from "@/lib/utils";
 
-function HoverCard({
-  ...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
-  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+interface HoverCardProps extends Omit<PopoverPrimitive.Root.Props, "children"> {
+  children: React.ReactNode;
+  openDelay?: number;
+  closeDelay?: number;
 }
 
-function HoverCardTrigger({
-  ...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+function HoverCard({
+  openDelay = 200,
+  closeDelay = 100,
+  children,
+  ...rootProps
+}: HoverCardProps) {
   return (
-    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+    <PopoverPrimitive.Root data-slot="hover-card" {...rootProps}>
+      <HoverCardDelayContext.Provider value={{ openDelay, closeDelay }}>
+        {children}
+      </HoverCardDelayContext.Provider>
+    </PopoverPrimitive.Root>
+  );
+}
+
+const HoverCardDelayContext = React.createContext({
+  openDelay: 200,
+  closeDelay: 100,
+});
+
+function HoverCardTrigger({
+  asChild,
+  children,
+  ...props
+}: PopoverPrimitive.Trigger.Props & {
+  asChild?: boolean;
+}) {
+  const { openDelay, closeDelay } = React.useContext(HoverCardDelayContext);
+  const triggerProps = {
+    ...props,
+    openOnHover: true,
+    delay: openDelay,
+    closeDelay,
+  };
+  if (asChild && React.isValidElement(children)) {
+    return (
+      <PopoverPrimitive.Trigger
+        data-slot="hover-card-trigger"
+        render={(mergeProps) =>
+          React.cloneElement(
+            children as React.ReactElement<object>,
+            mergeProps
+          )
+        }
+        {...triggerProps}
+      />
+    );
+  }
+  return (
+    <PopoverPrimitive.Trigger
+      data-slot="hover-card-trigger"
+      {...triggerProps}
+    >
+      {children}
+    </PopoverPrimitive.Trigger>
   );
 }
 
 function HoverCardContent({
   className,
   align = "center",
+  side = "bottom",
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+}: PopoverPrimitive.Popup.Props &
+  Pick<PopoverPrimitive.Positioner.Props, "align" | "side" | "sideOffset">) {
   return (
-    <HoverCardPrimitive.Portal>
-      <HoverCardPrimitive.Content
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
         align={align}
-        className={cn(
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-elevation-md)] outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in",
-          className
-        )}
-        data-slot="hover-card-content"
+        className="isolate z-50"
+        side={side}
         sideOffset={sideOffset}
-        {...props}
-      />
-    </HoverCardPrimitive.Portal>
+      >
+        <PopoverPrimitive.Popup
+          className={cn(
+            "data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-elevation-md)] outline-hidden data-closed:animate-out data-open:animate-in",
+            className
+          )}
+          data-slot="hover-card-content"
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
   );
 }
 

--- a/apps/web/src/components/ui/separator.tsx
+++ b/apps/web/src/components/ui/separator.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import * as React from "react";
-/** biome-ignore lint/performance/noNamespaceImport: shadcn/radix pattern */
-import { Separator as SeparatorPrimitive } from "radix-ui";
-
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 function Separator({
@@ -11,18 +9,22 @@ function Separator({
   orientation = "horizontal",
   decorative = true,
   ...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: React.ComponentProps<typeof SeparatorPrimitive> & {
+  decorative?: boolean;
+}) {
   return (
-    <SeparatorPrimitive.Root
+    <SeparatorPrimitive
+      aria-orientation={orientation}
       className={cn(
         "shrink-0 bg-border",
         orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
         className
       )}
-      decorative={decorative}
+      data-slot="separator"
+      role={decorative ? "none" : "separator"}
       orientation={orientation}
       {...props}
-  />
+    />
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Migrate `separator`, `context-menu`, and `hover-card` components from Radix UI to Base UI to standardize the UI library usage.

The `timeline` component was not migrated as Base UI does not provide equivalent `Direction` and `Slot` functionalities, thus Radix UI remains a dependency for it. The API for callers of the migrated components remains unchanged.

---
<p><a href="https://cursor.com/agents/bc-89886a7d-550c-42d7-ac13-a752ded9d4f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89886a7d-550c-42d7-ac13-a752ded9d4f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->